### PR TITLE
Fixed access to null pointer on hiDPI displays

### DIFF
--- a/src/gui_manager.cpp
+++ b/src/gui_manager.cpp
@@ -77,8 +77,11 @@ void manager::set_interface_scaling_factor(float fScalingFactor)
 
     pInputDispatcher_->set_interface_scaling_factor(fScalingFactor_);
 
-    pRoot_->notify_scaling_factor_updated();
-    pRoot_->notify_hovered_frame_dirty();
+    if (pRoot_)
+    {
+        pRoot_->notify_scaling_factor_updated();
+        pRoot_->notify_hovered_frame_dirty();
+    }
 }
 
 float manager::get_interface_scaling_factor() const


### PR DESCRIPTION
This PR fixes an unchecked nullptr access that was happening only on hi-DPI displays. Closes #103.