### PR TITLE
Strata improvement and fixes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -211,6 +211,7 @@ Other changes:
  - gui: fixed frame not marked as "user placed" when moved or resized
  - gui: fixed missing 'const' for slider::are_clicks_outside_thumb_allowed()
  - gui: fixed missing 'const' for region::render()
+ - gui: fixed status_bar not firing OnValueChanged
 
 v1.2.0:
  - added support for MSVC 2010

--- a/include/lxgui/gui_frame.hpp
+++ b/include/lxgui/gui_frame.hpp
@@ -1585,6 +1585,7 @@ protected:
 
     void add_level_(int amount);
 
+    void notify_frame_strata_changed_(frame_strata old_strata_id, frame_strata new_strata_id);
     void propagate_renderer_(bool rendered);
 
     void update_borders_() override;

--- a/include/lxgui/gui_frame.hpp
+++ b/include/lxgui/gui_frame.hpp
@@ -735,12 +735,6 @@ public:
     }
 
     /**
-     * \brief Calculates effective alpha.
-     * \return Effective alpha (alpha*parent->alpha)
-     */
-    float get_effective_alpha() const;
-
-    /**
      * \brief Calculates effective scale.
      * \return Effective scale (scale*parent->scale)
      */

--- a/include/lxgui/gui_frame.hpp
+++ b/include/lxgui/gui_frame.hpp
@@ -18,6 +18,7 @@
 #include <limits>
 #include <list>
 #include <lxgui/extern_sol2_protected_function.hpp>
+#include <magic_enum.hpp>
 #include <optional>
 #include <set>
 #include <unordered_map>
@@ -1633,7 +1634,7 @@ protected:
     child_list  child_list_;
     region_list region_list_;
 
-    static constexpr std::size_t num_layers = static_cast<std::size_t>(layer::enum_size);
+    static constexpr std::size_t num_layers = magic_enum::enum_count<layer>();
 
     std::array<layer_container, num_layers> layer_list_;
 

--- a/include/lxgui/gui_frame.hpp
+++ b/include/lxgui/gui_frame.hpp
@@ -756,6 +756,12 @@ public:
     frame_strata get_frame_strata() const;
 
     /**
+     * \brief Returns this frame's effective strata.
+     * \return This frame's strata, or its parent's effective strata if frame_strata::parent.
+     */
+    frame_strata get_effective_frame_strata() const;
+
+    /**
      * \brief Returns this frame's top-level parent.
      * \return This frame's top-level parent
      */
@@ -1267,12 +1273,6 @@ public:
     void set_frame_strata(frame_strata strata_id);
 
     /**
-     * \brief Sets this frame's strata.
-     * \param strata_name The new strata
-     */
-    void set_frame_strata(const std::string& strata_name);
-
-    /**
      * \brief Sets this frames' backdrop.
      * \param bdrop The new backdrop
      */
@@ -1589,6 +1589,13 @@ protected:
 
     void update_borders_() override;
 
+    /**
+     * \brief Changes this region's parent.
+     * \param parent The new parent
+     * \note Default is nullptr.
+     */
+    void set_parent_(utils::observer_ptr<frame> parent) override;
+
     utils::connection define_script_(
         const std::string& script_name,
         const std::string& content,
@@ -1623,7 +1630,7 @@ protected:
     std::set<std::string> reg_key_list_;
 
     int          level_        = 0;
-    frame_strata strata_       = frame_strata::medium;
+    frame_strata strata_       = frame_strata::parent;
     bool         is_top_level_ = false;
 
     utils::observer_ptr<frame_renderer> frame_renderer_ = nullptr;

--- a/include/lxgui/gui_frame.hpp
+++ b/include/lxgui/gui_frame.hpp
@@ -105,7 +105,7 @@ using script_list_view = script_signal::slot_list_view;
  * explicit key capture (@ref frame::enable_key_capture).
  * - Events related to mouse click input (`OnDragStart`, `OnDragStop`,
  * `OnMouseUp`, `OnMouseDown`) require frame::enable_mouse_click.
- * - Events related to mouse move input (`OnEnter`, `OnLeave`)
+ * - Events related to mouse move input (`OnEnter`, `OnLeave`, `OnMouseMove`)
  * require frame::enable_mouse_move.
  * - Events related to mouse wheel input (`OnMouseWheel`) require
  * frame::enable_mouse_wheel.
@@ -188,6 +188,11 @@ using script_list_view = script_signal::slot_list_view;
  * the registered callback: a number identifying the mouse button, a string
  * containing the human-readable name of this button (`"LeftButton"`,
  * `"RightButton"`, or `"MiddleButton"`), and the mouse X and Y position.
+ * - `OnMouseMove`: Triggered when the mouse moves over this frame, after
+ * `OnEnter` and until `OnLeave`. This event provides four argument to
+ * the registered callback: the amount of mouse movement in X and Y since the
+ * last call to `OnMouseMove` (or since the last position before the mouse
+ * entered this frame), and the mouse X and Y position.
  * - `OnMouseUp`: Similar to `OnMouseDown`, but triggered when the mouse button
  * is released.
  * - `OnMouseWheel`: Triggered when the mouse wheel is moved and this frame is

--- a/include/lxgui/gui_frame.hpp
+++ b/include/lxgui/gui_frame.hpp
@@ -1667,8 +1667,6 @@ protected:
     float min_height_ = 0.0f;
     float max_height_ = std::numeric_limits<float>::infinity();
 
-    vector2f old_size_;
-
     float scale_ = 1.0f;
 
     bool is_mouse_in_frame_ = false;

--- a/include/lxgui/gui_frame.hpp
+++ b/include/lxgui/gui_frame.hpp
@@ -6,6 +6,7 @@
 #include "lxgui/gui_frame_core_attributes.hpp"
 #include "lxgui/gui_layered_region.hpp"
 #include "lxgui/gui_region.hpp"
+#include "lxgui/gui_strata.hpp"
 #include "lxgui/input_keys.hpp"
 #include "lxgui/lxgui.hpp"
 #include "lxgui/utils.hpp"

--- a/include/lxgui/gui_frame_renderer.hpp
+++ b/include/lxgui/gui_frame_renderer.hpp
@@ -5,6 +5,7 @@
 #include "lxgui/lxgui.hpp"
 #include "lxgui/utils.hpp"
 #include "lxgui/utils_observer.hpp"
+#include "lxgui/utils_sorted_vector.hpp"
 
 #include <functional>
 
@@ -18,7 +19,7 @@ class color;
 class frame_renderer {
 public:
     /// Default constructor
-    frame_renderer() = default;
+    frame_renderer();
 
     /// Destructor
     virtual ~frame_renderer() = default;
@@ -92,10 +93,6 @@ public:
     int get_highest_level(frame_strata strata_id) const;
 
 protected:
-    void add_to_strata_list_(strata& strata_obj, const utils::observer_ptr<frame>& obj);
-    void remove_from_strata_list_(strata& strata_obj, const utils::observer_ptr<frame>& obj);
-    void add_to_level_list_(level& level_obj, const utils::observer_ptr<frame>& obj);
-    void remove_from_level_list_(level& level_obj, const utils::observer_ptr<frame>& obj);
     void clear_strata_list_();
     bool has_strata_list_changed_() const;
     void reset_strata_list_changed_flag_();
@@ -103,8 +100,19 @@ protected:
 
     void render_strata_(const strata& strata_obj) const;
 
+    struct frame_comparator {
+        bool operator()(
+            const utils::observer_ptr<frame>& f1, const utils::observer_ptr<frame>& f2) const;
+    };
+
+    using frame_list_type     = utils::sorted_vector<utils::observer_ptr<frame>, frame_comparator>;
+    using frame_list_iterator = frame_list_type::iterator;
+
+    std::pair<std::size_t, std::size_t> get_strata_range_(frame_strata strata_id) const;
+
     std::array<strata, 9> strata_list_;
-    bool                  strata_list_updated_ = false;
+    frame_list_type       sorted_frame_list_;
+    bool                  frame_list_updated_ = false;
 };
 
 } // namespace lxgui::gui

--- a/include/lxgui/gui_frame_renderer.hpp
+++ b/include/lxgui/gui_frame_renderer.hpp
@@ -8,6 +8,7 @@
 #include "lxgui/utils_sorted_vector.hpp"
 
 #include <functional>
+#include <magic_enum.hpp>
 
 namespace lxgui::gui {
 
@@ -109,9 +110,11 @@ protected:
 
     std::pair<std::size_t, std::size_t> get_strata_range_(frame_strata strata_id) const;
 
-    std::array<strata, 9> strata_list_;
-    frame_list_type       sorted_frame_list_;
-    bool                  frame_list_updated_ = false;
+    static constexpr std::size_t num_strata = magic_enum::enum_count<frame_strata>();
+
+    std::array<strata, num_strata> strata_list_;
+    frame_list_type                sorted_frame_list_;
+    bool                           frame_list_updated_ = false;
 };
 
 } // namespace lxgui::gui

--- a/include/lxgui/gui_frame_renderer.hpp
+++ b/include/lxgui/gui_frame_renderer.hpp
@@ -101,11 +101,10 @@ protected:
     void render_strata_(const strata& strata_obj) const;
 
     struct frame_comparator {
-        bool operator()(
-            const utils::observer_ptr<frame>& f1, const utils::observer_ptr<frame>& f2) const;
+        bool operator()(const frame* f1, const frame* f2) const;
     };
 
-    using frame_list_type     = utils::sorted_vector<utils::observer_ptr<frame>, frame_comparator>;
+    using frame_list_type     = utils::sorted_vector<frame*, frame_comparator>;
     using frame_list_iterator = frame_list_type::iterator;
 
     std::pair<std::size_t, std::size_t> get_strata_range_(frame_strata strata_id) const;

--- a/include/lxgui/gui_frame_renderer.hpp
+++ b/include/lxgui/gui_frame_renderer.hpp
@@ -103,7 +103,7 @@ protected:
 
     void render_strata_(const strata& strata_obj) const;
 
-    std::array<strata, 8> strata_list_;
+    std::array<strata, 9> strata_list_;
     bool                  strata_list_updated_ = false;
 };
 

--- a/include/lxgui/gui_layered_region.hpp
+++ b/include/lxgui/gui_layered_region.hpp
@@ -8,15 +8,7 @@
 namespace lxgui::gui {
 
 /// ID of a layer for rendering inside a frame.
-enum class layer {
-    background  = 0,
-    border      = 1,
-    artwork     = 2,
-    overlay     = 3,
-    highlight   = 4,
-    specialhigh = 5,
-    enum_size
-};
+enum class layer { background, border, artwork, overlay, highlight, special_high };
 
 /**
  * \brief A #region that can be rendered in a layer.

--- a/include/lxgui/gui_region.hpp
+++ b/include/lxgui/gui_region.hpp
@@ -767,16 +767,7 @@ protected:
      * \param parent The new parent
      * \note Default is nullptr.
      */
-    void set_parent_(utils::observer_ptr<frame> parent);
-
-    /**
-     * \brief Sets this region's name and parent at once.
-     * \param name This region's name
-     * \param parent The new parent
-     * \note The name can only be set once. If you need to just change the
-     * parent, call set_parent_().
-     */
-    void set_name_and_parent_(const std::string& name, utils::observer_ptr<frame> parent);
+    virtual void set_parent_(utils::observer_ptr<frame> parent);
 
     /**
      * \brief Set up function to call in all derived class constructors.

--- a/include/lxgui/gui_region.hpp
+++ b/include/lxgui/gui_region.hpp
@@ -593,16 +593,16 @@ public:
      * \return The renderer of this object or its parents
      * \note For more information, see frame::set_frame_renderer().
      */
-    virtual utils::observer_ptr<const frame_renderer> get_top_level_frame_renderer() const;
+    virtual utils::observer_ptr<const frame_renderer> get_effective_frame_renderer() const;
 
     /**
      * \brief Returns the renderer of this object or its parents, nullptr if none.
      * \return The renderer of this object or its parents, nullptr if none
      * \note For more information, see frame::set_frame_renderer().
      */
-    utils::observer_ptr<frame_renderer> get_top_level_frame_renderer() {
+    utils::observer_ptr<frame_renderer> get_effective_frame_renderer() {
         return utils::const_pointer_cast<frame_renderer>(
-            const_cast<const region*>(this)->get_top_level_frame_renderer());
+            const_cast<const region*>(this)->get_effective_frame_renderer());
     }
 
     /**

--- a/include/lxgui/gui_region.hpp
+++ b/include/lxgui/gui_region.hpp
@@ -6,7 +6,6 @@
 #include "lxgui/gui_color.hpp"
 #include "lxgui/gui_exception.hpp"
 #include "lxgui/gui_region_core_attributes.hpp"
-#include "lxgui/gui_strata.hpp"
 #include "lxgui/gui_vector2.hpp"
 #include "lxgui/lxgui.hpp"
 #include "lxgui/utils.hpp"

--- a/include/lxgui/gui_scroll_frame.hpp
+++ b/include/lxgui/gui_scroll_frame.hpp
@@ -187,7 +187,6 @@ protected:
 
     bool                           rebuild_scroll_render_target_flag_ = false;
     bool                           redraw_scroll_render_target_flag_  = false;
-    bool                           update_scroll_range_flag_          = false;
     std::shared_ptr<render_target> scroll_render_target_;
 
     utils::observer_ptr<texture> scroll_texture_ = nullptr;

--- a/include/lxgui/gui_status_bar.hpp
+++ b/include/lxgui/gui_status_bar.hpp
@@ -174,15 +174,6 @@ public:
      */
     bool is_reversed() const;
 
-    /**
-     * \brief Updates this region's logic.
-     * \param delta Time spent since last update
-     * \note Triggered callbacks could destroy the frame. If you need
-     * to use the frame again after calling this function, use
-     * the helper class alive_checker.
-     */
-    void update(float delta) override;
-
     /// Registers this region class to the provided Lua state
     static void register_on_lua(sol::state& lua);
 
@@ -194,8 +185,6 @@ protected:
 
     void parse_attributes_(const layout_node& node) override;
     void parse_all_nodes_before_children_(const layout_node& node) override;
-
-    bool update_bar_texture_flag_ = false;
 
     orientation orientation_ = orientation::horizontal;
     bool        is_reversed_ = false;

--- a/include/lxgui/gui_strata.hpp
+++ b/include/lxgui/gui_strata.hpp
@@ -16,8 +16,8 @@ namespace lxgui::gui {
 class frame;
 
 enum class frame_strata {
-    parent     = -1,
-    background = 0,
+    parent,
+    background,
     low,
     medium,
     high,
@@ -26,8 +26,6 @@ enum class frame_strata {
     fullscreen_dialog,
     tooltip
 };
-
-struct strata;
 
 /// Contains gui::frame
 struct level {

--- a/include/lxgui/gui_strata.hpp
+++ b/include/lxgui/gui_strata.hpp
@@ -16,7 +16,6 @@ namespace lxgui::gui {
 class frame;
 
 enum class frame_strata {
-    parent,
     background,
     low,
     medium,

--- a/include/lxgui/gui_strata.hpp
+++ b/include/lxgui/gui_strata.hpp
@@ -27,17 +27,13 @@ enum class frame_strata {
     tooltip
 };
 
-/// Contains gui::frame
-struct level {
-    std::vector<utils::observer_ptr<frame>> frame_list;
-};
-
-/// Contains gui::level
+/// Contains frames sorted by level
 struct strata {
-    std::map<int, level>           level_list;
-    bool                           redraw_flag = true;
-    std::shared_ptr<render_target> target;
-    quad                           target_quad;
+    frame_strata                        id;
+    std::pair<std::size_t, std::size_t> range;
+    bool                                redraw_flag = true;
+    std::shared_ptr<render_target>      target;
+    quad                                target_quad;
 };
 
 } // namespace lxgui::gui

--- a/include/lxgui/gui_texture.hpp
+++ b/include/lxgui/gui_texture.hpp
@@ -13,6 +13,7 @@
 namespace lxgui::gui {
 
 class renderer;
+class render_target;
 
 /**
  * \brief A layered_region that can draw images and colored rectangles.

--- a/include/lxgui/utils_sorted_vector.hpp
+++ b/include/lxgui/utils_sorted_vector.hpp
@@ -13,57 +13,57 @@ namespace lxgui::utils {
 /**
  * \brief Sorted std::vector wrapper.
  * This class is a light alternative to std::set.
-    Inspired from: [1] www.lafstern.org/matt/col1.pdf
+ * Inspired from: [1] www.lafstern.org/matt/col1.pdf
 
-    The sorted vector achieves the same O(log(N)) look up complexity as std::set, but with a
-    lower constant of proportionality thanks to the binary search algorithm (twice lower
-    according to [1]). The fact that this container uses an std::vector internally also implies
-    that it has the lowest possible memory usage.
+ * The sorted vector achieves the same O(log(N)) look up complexity as std::set, but with a
+ * lower constant of proportionality thanks to the binary search algorithm (twice lower
+ * according to [1]). The fact that this container uses an std::vector internally also implies
+ * that it has the lowest possible memory usage.
 
-    On the other hand, it has worse insertion complexity (O(N), compared to the O(log(N)) of
-    std::set). This drawback can be completely ignored if either:
+ * On the other hand, it has worse insertion complexity (O(N), compared to the O(log(N)) of
+ * std::set). This drawback can be completely ignored if either:
 
-     - one does much more look-ups than insertions,
-     - all the data are available when the vector is created, so that the insertions are all
-       performed in one go,
-     - and, even better, if one builds an already sorted std::vector and creates a sorted_vector
-       out of it.
+ *  - one does much more look-ups than insertions,
+ *  - all the data are available when the vector is created, so that the insertions are all
+ *    performed in one go,
+ *  - and, even better, if one builds an already sorted std::vector and creates a sorted_vector
+ *    out of it.
 
-    The elements of this container are sorted according to the Cmp template argument, which
-    defaults to std::less<T> (i.e. the elements are sorted using operator<()). One can provide
-    a custom comparison functor if std::less is not desirable. Using a custom comparison functor
-    can also allow to find elements by keys instead of their own value. For example, if T is
+ * The elements of this container are sorted according to the Cmp template argument, which
+ * defaults to std::less<T> (i.e. the elements are sorted using operator<()). One can provide
+ * a custom comparison functor if std::less is not desirable. Using a custom comparison functor
+ * can also allow to find elements by keys instead of their own value. For example, if T is
 
-    \code{.cpp}
-        struct test { int id; };
-    \endcode
+ * \code{.cpp}
+ *     struct test { int id; };
+ * \endcode
 
-    then one can use the following comparison functor:
+ * then one can use the following comparison functor:
 
-    \code{.cpp}
-        struct comp {
-            bool operator() (const test& n1, const test& n2) const {
-                return n1.id < n2.id;
-            }
-            bool operator() (const test& n1, int i) const {
-                return n1.id < i;
-            }
-            bool operator() (int i, const test& n2) const {
-                return i < n2.id;
-            }
-        };
-    \endcode
+ * \code{.cpp}
+ *     struct comp {
+ *         bool operator() (const test& n1, const test& n2) const {
+ *             return n1.id < n2.id;
+ *         }
+ *         bool operator() (const test& n1, int i) const {
+ *             return n1.id < i;
+ *         }
+ *         bool operator() (int i, const test& n2) const {
+ *             return i < n2.id;
+ *         }
+ *     };
+ * \endcode
 
-    and use an integer as the key to find elements in the
-    container
+ * and use an integer as the key to find elements in the
+ * container
 
-    \code{.cpp}
-        using vec_t = sorted_vector<test, comp>;
-        vec_t vec;
-        // ... fill vec with some data ...
-        // Then find the element that has the 'id' equal to 5
-        vec_t::iterator it = vec.find(5);
-    \endcode
+ * \code{.cpp}
+ *     using vec_t = sorted_vector<test, comp>;
+ *     vec_t vec;
+ *     // ... fill vec with some data ...
+ *     // Then find the element that has the 'id' equal to 5
+ *     vec_t::iterator it = vec.find(5);
+ * \endcode
 **/
 template<typename T, typename Cmp = std::less<T>>
 class sorted_vector : private std::vector<T> {
@@ -88,8 +88,8 @@ public:
     /**
      * \brief Move another sorted_vector into this one.
      * The other vector is left empty in the process, and all its content is transfered into
-        this new one.
-    **/
+     * this new one.
+     **/
     sorted_vector(sorted_vector&& s) = default;
 
     /// Copy another sorted_vector into this one.
@@ -98,8 +98,8 @@ public:
     /**
      * \brief Move another vector into this one.
      * The other vector is left empty in the process, and all its content is transfered into
-        this new one.
-    **/
+     * this new one.
+     **/
     sorted_vector& operator=(sorted_vector&& s) = default;
 
     /**
@@ -111,9 +111,9 @@ public:
     /**
      * \brief Move a pre-built vector into this one.
      * The provided vector must be sorted, and shall not contain any duplicate value. It is
-        left empty in the process, and all its content is transfered into this new
-        sorted_vector.
-    **/
+     * left empty in the process, and all its content is transfered into this new
+     * sorted_vector.
+     **/
     explicit sorted_vector(base&& s) : base(std::move(s)) {}
 
     /**
@@ -132,32 +132,47 @@ public:
         }
     }
 
+    /// Return the comparator object.
+    Cmp& comparator() {
+        return compare;
+    }
+
+    /// Return the comparator object.
+    const Cmp& comparator() const {
+        return compare;
+    }
+
     /**
-     * \brief Insert a copy of the provided object in the vector.
-     * If an object already exists with the same key, it is destroyed and replaced by this
-        copy.
-    **/
-    iterator insert(const T& t) {
-        return insert(T(t));
+     * \brief Insert the provided object in the vector, only if no object exists with the same key.
+     * \note If an object already exists with the same key, the vector is unchanged and the boolean
+     * in the returned pair is set to false. Else, the vector is modified and the boolean is
+     * set to true.
+     **/
+    template<typename U>
+    std::pair<iterator, bool> insert(U&& t) {
+        if (empty()) {
+            base::push_back(std::forward<U>(t));
+            return {base::begin(), true};
+        } else {
+            auto iter = std::lower_bound(base::begin(), base::end(), t, compare);
+            if (iter != base::end() && !compare(t, *iter)) {
+                return {iter, false};
+            } else {
+                return {base::insert(iter, std::forward<U>(t)), true};
+            }
+        }
     }
 
     /**
      * \brief Insert the provided object in the vector.
-     * If an object already exists with the same key, it is destroyed and replaced by this one.
+     * \note If an object already exists with the same key, it is destroyed and replaced by this one.
      **/
-    iterator insert(T&& t) {
-        if (empty()) {
-            base::push_back(std::move(t));
-            return base::begin();
-        } else {
-            auto iter = std::lower_bound(begin(), end(), t, compare);
-            if (iter != end() && !compare(t, *iter)) {
-                *iter = std::move(t);
-            } else {
-                iter = base::insert(iter, std::move(t));
-            }
-            return iter;
-        }
+    template<typename U>
+    iterator insert_or_assign(U&& t) {
+        auto [iter, inserted] = insert(std::forward<U>(t));
+        if (!inserted)
+            *iter = std::forward<U>(t);
+        return iter;
     }
 
     /// Erase an element from this vector.
@@ -173,9 +188,9 @@ public:
     /**
      * \brief Erase an element from this vector by its key.
      * The key can be a copy of the element itself, or any other object that is supported by
-        the chosen comparison function. If no object is found with that key, this function does
-        nothing.
-    **/
+     * the chosen comparison function. If no object is found with that key, this function does
+     * nothing.
+     **/
     template<typename Key>
     iterator erase(const Key& k) {
         auto iter = find(k);
@@ -189,8 +204,8 @@ public:
     /**
      * \brief Find an object in this vector by its key.
      * The key can be a copy of the element itself, or any other object that is supported by
-        the chosen comparison function. If no element is found, this function returns end().
-    **/
+     * the chosen comparison function. If no element is found, this function returns end().
+     **/
     template<typename Key>
     iterator find(const Key& k) {
         if (!empty()) {
@@ -205,8 +220,8 @@ public:
     /**
      * \brief Find an object in this vector by its key.
      * The key can be a copy of the element itself, or any other object that is supported by
-        the chosen comparison function. If no element is found, this function returns end().
-    **/
+     * the chosen comparison function. If no element is found, this function returns end().
+     **/
     template<typename Key>
     const_iterator find(const Key& k) const {
         if (!empty()) {

--- a/include/lxgui/utils_sorted_vector.hpp
+++ b/include/lxgui/utils_sorted_vector.hpp
@@ -1,0 +1,239 @@
+#ifndef LXGUI_SORTED_VECTOR_HPP
+#define LXGUI_SORTED_VECTOR_HPP
+
+#include "lxgui/lxgui.hpp"
+
+#include <algorithm>
+#include <functional>
+#include <memory>
+#include <vector>
+
+namespace lxgui::utils {
+
+/**
+ * \brief Sorted std::vector wrapper.
+ * This class is a light alternative to std::set.
+    Inspired from: [1] www.lafstern.org/matt/col1.pdf
+
+    The sorted vector achieves the same O(log(N)) look up complexity as std::set, but with a
+    lower constant of proportionality thanks to the binary search algorithm (twice lower
+    according to [1]). The fact that this container uses an std::vector internally also implies
+    that it has the lowest possible memory usage.
+
+    On the other hand, it has worse insertion complexity (O(N), compared to the O(log(N)) of
+    std::set). This drawback can be completely ignored if either:
+
+     - one does much more look-ups than insertions,
+     - all the data are available when the vector is created, so that the insertions are all
+       performed in one go,
+     - and, even better, if one builds an already sorted std::vector and creates a sorted_vector
+       out of it.
+
+    The elements of this container are sorted according to the Cmp template argument, which
+    defaults to std::less<T> (i.e. the elements are sorted using operator<()). One can provide
+    a custom comparison functor if std::less is not desirable. Using a custom comparison functor
+    can also allow to find elements by keys instead of their own value. For example, if T is
+
+    \code{.cpp}
+        struct test { int id; };
+    \endcode
+
+    then one can use the following comparison functor:
+
+    \code{.cpp}
+        struct comp {
+            bool operator() (const test& n1, const test& n2) const {
+                return n1.id < n2.id;
+            }
+            bool operator() (const test& n1, int i) const {
+                return n1.id < i;
+            }
+            bool operator() (int i, const test& n2) const {
+                return i < n2.id;
+            }
+        };
+    \endcode
+
+    and use an integer as the key to find elements in the
+    container
+
+    \code{.cpp}
+        using vec_t = sorted_vector<test, comp>;
+        vec_t vec;
+        // ... fill vec with some data ...
+        // Then find the element that has the 'id' equal to 5
+        vec_t::iterator it = vec.find(5);
+    \endcode
+**/
+template<typename T, typename Cmp = std::less<T>>
+class sorted_vector : private std::vector<T> {
+    using base = std::vector<T>;
+    Cmp compare;
+
+public:
+    using iterator               = typename base::iterator;
+    using const_iterator         = typename base::const_iterator;
+    using reverse_iterator       = typename base::reverse_iterator;
+    using const_reverse_iterator = typename base::const_reverse_iterator;
+
+    /**
+     * \brief Default constructor.
+     * Creates an empty vector.
+     **/
+    sorted_vector() = default;
+
+    /// Copy another vector into this one.
+    sorted_vector(const sorted_vector& s) = default;
+
+    /**
+     * \brief Move another sorted_vector into this one.
+     * The other vector is left empty in the process, and all its content is transfered into
+        this new one.
+    **/
+    sorted_vector(sorted_vector&& s) = default;
+
+    /// Copy another sorted_vector into this one.
+    sorted_vector& operator=(const sorted_vector& s) = default;
+
+    /**
+     * \brief Move another vector into this one.
+     * The other vector is left empty in the process, and all its content is transfered into
+        this new one.
+    **/
+    sorted_vector& operator=(sorted_vector&& s) = default;
+
+    /**
+     * \brief Copy a pre-built vector into this one.
+     * The provided vector must be sorted, and shall not contain any duplicate value.
+     **/
+    explicit sorted_vector(const base& s) : base(s) {}
+
+    /**
+     * \brief Move a pre-built vector into this one.
+     * The provided vector must be sorted, and shall not contain any duplicate value. It is
+        left empty in the process, and all its content is transfered into this new
+        sorted_vector.
+    **/
+    explicit sorted_vector(base&& s) : base(std::move(s)) {}
+
+    /**
+     * \brief Default constructor, with comparator.
+     * Creates an empty vector and sets the comparator function.
+     **/
+    explicit sorted_vector(const Cmp& c) : compare(c) {}
+
+    /**
+     * \brief Write an initializer list into this vector.
+     * The list need not be sorted.
+     **/
+    sorted_vector(std::initializer_list<T> l) {
+        for (auto& e : l) {
+            insert(e);
+        }
+    }
+
+    /**
+     * \brief Insert a copy of the provided object in the vector.
+     * If an object already exists with the same key, it is destroyed and replaced by this
+        copy.
+    **/
+    iterator insert(const T& t) {
+        return insert(T(t));
+    }
+
+    /**
+     * \brief Insert the provided object in the vector.
+     * If an object already exists with the same key, it is destroyed and replaced by this one.
+     **/
+    iterator insert(T&& t) {
+        if (empty()) {
+            base::push_back(std::move(t));
+            return base::begin();
+        } else {
+            auto iter = std::lower_bound(begin(), end(), t, compare);
+            if (iter != end() && !compare(t, *iter)) {
+                *iter = std::move(t);
+            } else {
+                iter = base::insert(iter, std::move(t));
+            }
+            return iter;
+        }
+    }
+
+    /// Erase an element from this vector.
+    iterator erase(iterator iter) {
+        return base::erase(iter);
+    }
+
+    /// Erase a range from this vector.
+    iterator erase(iterator first, iterator last) {
+        return base::erase(first, last);
+    }
+
+    /**
+     * \brief Erase an element from this vector by its key.
+     * The key can be a copy of the element itself, or any other object that is supported by
+        the chosen comparison function. If no object is found with that key, this function does
+        nothing.
+    **/
+    template<typename Key>
+    iterator erase(const Key& k) {
+        auto iter = find(k);
+        if (iter != end()) {
+            return base::erase(iter);
+        } else {
+            return end();
+        }
+    }
+
+    /**
+     * \brief Find an object in this vector by its key.
+     * The key can be a copy of the element itself, or any other object that is supported by
+        the chosen comparison function. If no element is found, this function returns end().
+    **/
+    template<typename Key>
+    iterator find(const Key& k) {
+        if (!empty()) {
+            auto iter = std::lower_bound(begin(), end(), k, compare);
+            if (iter != end() && !compare(k, *iter)) {
+                return iter;
+            }
+        }
+        return end();
+    }
+
+    /**
+     * \brief Find an object in this vector by its key.
+     * The key can be a copy of the element itself, or any other object that is supported by
+        the chosen comparison function. If no element is found, this function returns end().
+    **/
+    template<typename Key>
+    const_iterator find(const Key& k) const {
+        if (!empty()) {
+            auto iter = std::lower_bound(begin(), end(), k, compare);
+            if (iter != end() && !compare(k, *iter)) {
+                return iter;
+            }
+        }
+        return end();
+    }
+
+    using base::back;
+    using base::capacity;
+    using base::clear;
+    using base::empty;
+    using base::front;
+    using base::max_size;
+    using base::pop_back;
+    using base::reserve;
+    using base::size;
+
+    using base::begin;
+    using base::end;
+    using base::rbegin;
+    using base::rend;
+};
+
+} // namespace lxgui::utils
+
+#endif

--- a/src/gui_addon_registry.cpp
+++ b/src/gui_addon_registry.cpp
@@ -103,10 +103,9 @@ void addon_registry::load_addon_files_(const addon& a) {
     for (const auto& file : a.file_list) {
         const std::string extension = utils::get_file_extension(file);
         if (extension == ".lua") {
-            try {
-                lua_.do_file(file);
-            } catch (const sol::error& e) {
-                std::string err = e.what();
+            auto result = lua_.do_file(file);
+            if (!result.valid()) {
+                std::string err = result.get<sol::error>().what();
                 gui::out << gui::error << err << std::endl;
                 event_emitter_.fire_event("LUA_ERROR", {err});
             }
@@ -117,11 +116,11 @@ void addon_registry::load_addon_files_(const addon& a) {
 
     std::string saved_variables_file =
         "saves/interface/" + a.main_directory + "/" + a.name + ".lua";
+
     if (utils::file_exists(saved_variables_file)) {
-        try {
-            lua_.do_file(saved_variables_file);
-        } catch (const sol::error& e) {
-            std::string err = e.what();
+        auto result = lua_.do_file(saved_variables_file);
+        if (!result.valid()) {
+            std::string err = result.get<sol::error>().what();
             gui::out << gui::error << err << std::endl;
             event_emitter_.fire_event("LUA_ERROR", {err});
         }

--- a/src/gui_addon_registry_parser.cpp
+++ b/src/gui_addon_registry_parser.cpp
@@ -242,10 +242,9 @@ void addon_registry::parse_layout_file_(const std::string& file_name, const addo
             std::string script_file =
                 add_on.directory + "/" + node.get_attribute_value<std::string>("file");
 
-            try {
-                lua_.do_file(script_file);
-            } catch (const sol::error& e) {
-                std::string err = e.what();
+            auto result = lua_.do_file(script_file);
+            if (!result.valid()) {
+                std::string err = result.get<sol::error>().what();
                 gui::out << gui::error << err << std::endl;
                 event_emitter_.fire_event("LUA_ERROR", {err});
             }

--- a/src/gui_anchor.cpp
+++ b/src/gui_anchor.cpp
@@ -59,7 +59,7 @@ vector2f anchor::get_point(const region& object) const {
         parent_pos  = raw_parent->get_borders().top_left();
         parent_size = raw_parent->get_apparent_dimensions();
     } else {
-        parent_size = object.get_top_level_frame_renderer()->get_target_dimensions();
+        parent_size = object.get_effective_frame_renderer()->get_target_dimensions();
     }
 
     vector2f offset_abs;

--- a/src/gui_edit_box.cpp
+++ b/src/gui_edit_box.cpp
@@ -121,7 +121,7 @@ void edit_box::fire_script(const std::string& script_name, const event_data& dat
             return;
     }
 
-    if (script_name == "OnKeyDown" && has_focus()) {
+    if ((script_name == "OnKeyDown" || script_name == "OnKeyRepeat") && has_focus()) {
         key  key_id           = data.get<key>(0);
         bool shift_is_pressed = data.get<bool>(1);
         bool ctrl_is_pressed  = data.get<bool>(2);

--- a/src/gui_frame.cpp
+++ b/src/gui_frame.cpp
@@ -693,13 +693,6 @@ frame::const_child_list_view frame::get_children() const {
     return const_child_list_view(child_list_);
 }
 
-float frame::get_effective_alpha() const {
-    if (parent_)
-        return alpha_ * parent_->get_effective_alpha();
-    else
-        return alpha_;
-}
-
 float frame::get_effective_scale() const {
     if (parent_)
         return scale_ * parent_->get_effective_scale();

--- a/src/gui_frame.cpp
+++ b/src/gui_frame.cpp
@@ -179,9 +179,9 @@ bool frame::can_use_script(const std::string& script_name) const {
            script_name == "OnHide" || script_name == "OnKeyDown" || script_name == "OnKeyUp" ||
            script_name == "OnKeyRepeat" || script_name == "OnLeave" || script_name == "OnLoad" ||
            script_name == "OnMouseDown" || script_name == "OnMouseUp" ||
-           script_name == "OnDoubleClick" || script_name == "OnMouseWheel" ||
-           script_name == "OnReceiveDrag" || script_name == "OnShow" ||
-           script_name == "OnSizeChanged" || script_name == "OnUpdate";
+           script_name == "OnMouseMove" || script_name == "OnDoubleClick" ||
+           script_name == "OnMouseWheel" || script_name == "OnReceiveDrag" ||
+           script_name == "OnShow" || script_name == "OnSizeChanged" || script_name == "OnUpdate";
 }
 
 void frame::copy_from(const region& obj) {

--- a/src/gui_frame.cpp
+++ b/src/gui_frame.cpp
@@ -1509,7 +1509,16 @@ void frame::update_borders_() {
     check_position_();
 
     if (border_list_ != old_border_list || is_ready_ != old_ready) {
+        if (border_list_.width() != old_border_list.width() ||
+            border_list_.height() != old_border_list.height()) {
+            alive_checker checker(*this);
+            fire_script("OnSizeChanged");
+            if (!checker.is_alive())
+                return;
+        }
+
         get_manager().get_root().notify_hovered_frame_dirty();
+
         if (backdrop_)
             backdrop_->notify_borders_updated();
     }
@@ -1590,15 +1599,6 @@ void frame::update(float delta) {
                 ++iter_list;
             }
         }
-    }
-
-    vector2f new_size = get_apparent_dimensions();
-    if (old_size_ != new_size) {
-        fire_script("OnSizeChanged");
-        if (!checker.is_alive())
-            return;
-
-        old_size_ = new_size;
     }
 }
 

--- a/src/gui_frame_glues.cpp
+++ b/src/gui_frame_glues.cpp
@@ -439,8 +439,12 @@ void frame::register_on_lua(sol::state& lua) {
 
     /** @function get_frame_strata
      */
-    type.set_function("get_frame_strata", [](const frame& self) {
-        return utils::to_string(self.get_frame_strata());
+    type.set_function("get_frame_strata", [](const frame& self) -> sol::optional<std::string> {
+        auto strata_id = self.get_frame_strata();
+        if (strata_id.has_value())
+            return utils::to_string(strata_id.value());
+        else
+            return sol::nullopt;
     });
 
     /** @function get_frame_strata
@@ -660,12 +664,17 @@ void frame::register_on_lua(sol::state& lua) {
 
     /** @function set_frame_strata
      */
-    type.set_function("set_frame_strata", [](frame& self, const std::string& strata_name) {
-        if (auto converted = utils::from_string<frame_strata>(strata_name); converted.has_value()) {
-            self.set_frame_strata(converted.value());
+    type.set_function("set_frame_strata", [](frame& self, sol::optional<std::string> strata_name) {
+        if (!strata_name.has_value()) {
+            self.set_frame_strata(std::nullopt);
         } else {
-            gui::out << gui::warning << "Frame.set_frame_strata: "
-                     << "Unknown strata type: \"" << strata_name << "\"." << std::endl;
+            if (auto converted = utils::from_string<frame_strata>(strata_name.value());
+                converted.has_value()) {
+                self.set_frame_strata(converted.value());
+            } else {
+                gui::out << gui::warning << "Frame.set_frame_strata: "
+                         << "Unknown strata type: \"" << strata_name.value() << "\"." << std::endl;
+            }
         }
     });
 

--- a/src/gui_frame_glues.cpp
+++ b/src/gui_frame_glues.cpp
@@ -67,7 +67,7 @@
  * explicit key capture (see @{Frame:enable_key_capture}).
  * - Events related to mouse click input (`OnDragStart`, `OnDragStop`,
  * `OnMouseUp`, `OnMouseDown`) require @{Frame:enable_mouse_click}.
- * - Events related to mouse move input (`OnEnter`, `OnLeave`)
+ * - Events related to mouse move input (`OnEnter`, `OnLeave`, `OnMouseMove`)
  * require @{Frame:enable_mouse_move}.
  * - Events related to mouse wheel input (`OnMouseWheel`) require
  * @{Frame:enable_mouse_wheel}.
@@ -150,6 +150,11 @@
  * the registered callback: a number identifying the mouse button, a string
  * containing the human-readable name of this button (`"LeftButton"`,
  * `"RightButton"`, or `"MiddleButton"`), and the mouse X and Y position.
+ * - `OnMouseMove`: Triggered when the mouse moves over this frame, after
+ * `OnEnter` and until `OnLeave`. This event provides four argument to
+ * the registered callback: the amount of mouse movement in X and Y since the
+ * last call to `OnMouseMove` (or since the last position before the mouse
+ * entered this frame), and the mouse X and Y position.
  * - `OnMouseUp`: Similar to `OnMouseDown`, but triggered when the mouse button
  * is released.
  * - `OnMouseWheel`: Triggered when the mouse wheel is moved and this frame is

--- a/src/gui_frame_glues.cpp
+++ b/src/gui_frame_glues.cpp
@@ -439,26 +439,14 @@ void frame::register_on_lua(sol::state& lua) {
 
     /** @function get_frame_strata
      */
-    type.set_function("get_frame_strata", [](const frame& self) -> sol::optional<std::string> {
-        frame_strata strata_id = self.get_frame_strata();
-        if (strata_id == frame_strata::background)
-            return std::string("BACKGROUND");
-        else if (strata_id == frame_strata::low)
-            return std::string("LOW");
-        else if (strata_id == frame_strata::medium)
-            return std::string("MEDIUM");
-        else if (strata_id == frame_strata::high)
-            return std::string("HIGH");
-        else if (strata_id == frame_strata::dialog)
-            return std::string("DIALOG");
-        else if (strata_id == frame_strata::fullscreen)
-            return std::string("FULLSCREEN");
-        else if (strata_id == frame_strata::fullscreen_dialog)
-            return std::string("FULLSCREEN_DIALOG");
-        else if (strata_id == frame_strata::tooltip)
-            return std::string("TOOLTIP");
-        else
-            return {};
+    type.set_function("get_frame_strata", [](const frame& self) {
+        return utils::to_string(self.get_frame_strata());
+    });
+
+    /** @function get_frame_strata
+     */
+    type.set_function("get_effective_frame_strata", [](const frame& self) {
+        return utils::to_string(self.get_effective_frame_strata());
     });
 
     /** @function get_frame_type
@@ -672,10 +660,14 @@ void frame::register_on_lua(sol::state& lua) {
 
     /** @function set_frame_strata
      */
-    type.set_function(
-        "set_frame_strata",
-        member_function< // select the right overload for Lua
-            static_cast<void (frame::*)(const std::string&)>(&frame::set_frame_strata)>());
+    type.set_function("set_frame_strata", [](frame& self, const std::string& strata_name) {
+        if (auto converted = utils::from_string<frame_strata>(strata_name); converted.has_value()) {
+            self.set_frame_strata(converted.value());
+        } else {
+            gui::out << gui::warning << "Frame.set_frame_strata: "
+                     << "Unknown strata type: \"" << strata_name << "\"." << std::endl;
+        }
+    });
 
     /** @function set_hit_rect_insets
      */

--- a/src/gui_frame_parser.cpp
+++ b/src/gui_frame_parser.cpp
@@ -57,8 +57,13 @@ void frame::parse_attributes_(const layout_node& node) {
                      << "\"frameLevel\" is not allowed for virtual regions. Ignored." << std::endl;
         }
     }
+
     if (const layout_attribute* attr = node.try_get_attribute("enableMouse"))
         enable_mouse(attr->get_value<bool>());
+    if (const layout_attribute* attr = node.try_get_attribute("enableMouseMove"))
+        enable_mouse_move(attr->get_value<bool>());
+    if (const layout_attribute* attr = node.try_get_attribute("enableMouseClick"))
+        enable_mouse_click(attr->get_value<bool>());
     if (const layout_attribute* attr = node.try_get_attribute("enableMouseWheel"))
         enable_mouse_wheel(attr->get_value<bool>());
     if (const layout_attribute* attr = node.try_get_attribute("enableKeyboard"))

--- a/src/gui_frame_parser.cpp
+++ b/src/gui_frame_parser.cpp
@@ -44,8 +44,8 @@ void frame::parse_attributes_(const layout_node& node) {
         set_movable(attr->get_value<bool>());
     if (const layout_attribute* attr = node.try_get_attribute("resizable"))
         set_resizable(attr->get_value<bool>());
-
-    set_frame_strata(node.get_attribute_value_or<std::string>("frameStrata", "PARENT"));
+    if (const layout_attribute* attr = node.try_get_attribute("frameStrata"))
+        set_frame_strata(attr->get_value<frame_strata>());
 
     if (const layout_attribute* attr = node.try_get_attribute("frameLevel")) {
         if (!is_virtual_) {

--- a/src/gui_frame_renderer.cpp
+++ b/src/gui_frame_renderer.cpp
@@ -7,7 +7,8 @@
 namespace lxgui::gui {
 
 // For debugging only
-std::size_t count_frames(const std::array<strata, 8>& strata_list) {
+template<typename T>
+std::size_t count_frames(const T& strata_list) {
     std::size_t count = 0;
     for (std::size_t strata_id = 0; strata_id < strata_list.size(); ++strata_id) {
         for (const auto& level_obj : utils::range::value(strata_list[strata_id].level_list)) {
@@ -19,7 +20,8 @@ std::size_t count_frames(const std::array<strata, 8>& strata_list) {
 }
 
 // For debugging only
-void print_frames(const std::array<strata, 8>& strata_list) {
+template<typename T>
+void print_frames(const T& strata_list) {
     for (std::size_t strata_id = 0; strata_id < strata_list.size(); ++strata_id) {
         if (strata_list[strata_id].level_list.empty())
             continue;

--- a/src/gui_frame_renderer.cpp
+++ b/src/gui_frame_renderer.cpp
@@ -14,49 +14,38 @@ struct strata_comparator {
         return strata_id1 < strata_id2;
     }
 
-    bool operator()(const utils::observer_ptr<frame>& f1, frame_strata s2) const {
-        frame* rf1 = f1.get();
-        return operator()(rf1->get_effective_frame_strata(), s2);
+    bool operator()(const frame* f1, frame_strata s2) const {
+        return operator()(f1->get_effective_frame_strata(), s2);
     }
 
-    bool operator()(frame_strata s1, const utils::observer_ptr<frame>& f2) const {
-        frame* rf2 = f2.get();
-        return operator()(s1, rf2->get_effective_frame_strata());
+    bool operator()(frame_strata s1, const frame* f2) const {
+        return operator()(s1, f2->get_effective_frame_strata());
     }
 
-    bool
-    operator()(const utils::observer_ptr<frame>& f1, const utils::observer_ptr<frame>& f2) const {
-        frame* rf1 = f1.get();
-        frame* rf2 = f2.get();
-
-        return operator()(rf1->get_effective_frame_strata(), rf2->get_effective_frame_strata());
+    bool operator()(const frame* f1, const frame* f2) const {
+        return operator()(f1->get_effective_frame_strata(), f2->get_effective_frame_strata());
     }
 };
 
-bool frame_renderer::frame_comparator::operator()(
-    const utils::observer_ptr<frame>& f1, const utils::observer_ptr<frame>& f2) const {
-
-    frame* rf1 = f1.get();
-    frame* rf2 = f2.get();
-
+bool frame_renderer::frame_comparator::operator()(const frame* f1, const frame* f2) const {
     using int_type        = std::underlying_type_t<frame_strata>;
-    const auto strata_id1 = static_cast<int_type>(rf1->get_effective_frame_strata());
-    const auto strata_id2 = static_cast<int_type>(rf2->get_effective_frame_strata());
+    const auto strata_id1 = static_cast<int_type>(f1->get_effective_frame_strata());
+    const auto strata_id2 = static_cast<int_type>(f2->get_effective_frame_strata());
 
     if (strata_id1 < strata_id2)
         return true;
     if (strata_id1 > strata_id2)
         return false;
 
-    const auto level1 = rf1->get_level();
-    const auto level2 = rf2->get_level();
+    const auto level1 = f1->get_level();
+    const auto level2 = f2->get_level();
 
     if (level1 < level2)
         return true;
     if (level1 > level2)
         return false;
 
-    return rf1 < rf2;
+    return f1 < f2;
 }
 
 frame_renderer::frame_renderer() {
@@ -83,13 +72,13 @@ void frame_renderer::notify_rendered_frame(const utils::observer_ptr<frame>& obj
     }
 
     if (rendered) {
-        auto [iter, inserted] = sorted_frame_list_.insert(obj);
+        auto [iter, inserted] = sorted_frame_list_.insert(obj.get());
         if (!inserted) {
             // Frame was already registered...
             return;
         }
     } else {
-        sorted_frame_list_.erase(obj);
+        sorted_frame_list_.erase(obj.get());
     }
 
     for (std::size_t i = 0; i < strata_list_.size(); ++i) {
@@ -149,10 +138,9 @@ void frame_renderer::notify_frame_level_changed(
 utils::observer_ptr<const frame>
 frame_renderer::find_topmost_frame(const std::function<bool(const frame&)>& predicate) const {
     // Iterate through the frames in reverse order from rendering (frame on top goes first)
-    for (const auto& obj : utils::range::reverse(sorted_frame_list_)) {
-        // NB: can use raw_get because we know frames ask to not be rendered before deletion
-        if (const frame* raw_ptr = obj.raw_get(); raw_ptr->is_visible()) {
-            if (auto topmost = raw_ptr->find_topmost_frame(predicate))
+    for (const auto* obj : utils::range::reverse(sorted_frame_list_)) {
+        if (obj->is_visible()) {
+            if (auto topmost = obj->find_topmost_frame(predicate))
                 return topmost;
         }
     }
@@ -178,8 +166,7 @@ void frame_renderer::render_strata_(const strata& strata_obj) const {
     auto end   = sorted_frame_list_.begin() + strata_obj.range.second;
 
     for (auto iter = begin; iter != end; ++iter) {
-        // NB: can use raw_get because we know frames ask to not be rendered before deletion
-        iter->raw_get()->render();
+        (*iter)->render();
     }
 }
 

--- a/src/gui_frame_renderer.cpp
+++ b/src/gui_frame_renderer.cpp
@@ -46,8 +46,12 @@ void frame_renderer::notify_rendered_frame(const utils::observer_ptr<frame>& obj
     if (!obj)
         return;
 
-    const auto frame_strata = obj->get_effective_frame_strata();
-    auto&      strata       = strata_list_[static_cast<std::size_t>(frame_strata)];
+    const auto strata_id = obj->get_effective_frame_strata();
+    if (strata_id == frame_strata::parent) {
+        throw gui::exception("gui::frame_renderer", "cannot use PARENT strata for renderer");
+    }
+
+    auto& strata = strata_list_[static_cast<std::size_t>(strata_id)];
 
     if (rendered)
         add_to_strata_list_(strata, obj);

--- a/src/gui_frame_renderer.cpp
+++ b/src/gui_frame_renderer.cpp
@@ -43,15 +43,10 @@ void frame_renderer::notify_strata_needs_redraw(frame_strata strata_id) {
 }
 
 void frame_renderer::notify_rendered_frame(const utils::observer_ptr<frame>& obj, bool rendered) {
-
     if (!obj)
         return;
 
-    if (obj->get_frame_strata() == frame_strata::parent) {
-        throw gui::exception("gui::frame_renderer", "cannot use PARENT strata for renderer");
-    }
-
-    const auto frame_strata = obj->get_frame_strata();
+    const auto frame_strata = obj->get_effective_frame_strata();
     auto&      strata       = strata_list_[static_cast<std::size_t>(frame_strata)];
 
     if (rendered)
@@ -82,11 +77,7 @@ void frame_renderer::notify_frame_strata_changed(
 void frame_renderer::notify_frame_level_changed(
     const utils::observer_ptr<frame>& obj, int old_level, int new_level) {
 
-    if (obj->get_frame_strata() == frame_strata::parent) {
-        throw gui::exception("gui::frame_renderer", "cannot use PARENT strata for renderer");
-    }
-
-    const auto strata_id  = obj->get_frame_strata();
+    const auto strata_id  = obj->get_effective_frame_strata();
     auto&      strata_obj = strata_list_[static_cast<std::size_t>(strata_id)];
     auto&      level_list = strata_obj.level_list;
 

--- a/src/gui_region.cpp
+++ b/src/gui_region.cpp
@@ -731,10 +731,15 @@ void region::notify_borders_need_update() {
     if (is_virtual())
         return;
 
+    const bool old_ready       = is_ready_;
+    const auto old_border_list = border_list_;
+
     update_borders_();
 
-    for (const auto& object : anchored_object_list_)
-        object->notify_borders_need_update();
+    if (border_list_ != old_border_list || is_ready_ != old_ready) {
+        for (const auto& object : anchored_object_list_)
+            object->notify_borders_need_update();
+    }
 }
 
 void region::notify_scaling_factor_updated() {

--- a/src/gui_region.cpp
+++ b/src/gui_region.cpp
@@ -258,21 +258,21 @@ void region::set_relative_dimensions(const vector2f& dimensions) {
     if (parent_)
         set_dimensions(dimensions * parent_->get_apparent_dimensions());
     else
-        set_dimensions(dimensions * get_top_level_frame_renderer()->get_target_dimensions());
+        set_dimensions(dimensions * get_effective_frame_renderer()->get_target_dimensions());
 }
 
 void region::set_relative_width(float rel_width) {
     if (parent_)
         set_width(rel_width * parent_->get_apparent_dimensions().x);
     else
-        set_width(rel_width * get_top_level_frame_renderer()->get_target_dimensions().x);
+        set_width(rel_width * get_effective_frame_renderer()->get_target_dimensions().x);
 }
 
 void region::set_relative_height(float rel_height) {
     if (parent_)
         set_height(rel_height * parent_->get_apparent_dimensions().y);
     else
-        set_height(rel_height * get_top_level_frame_renderer()->get_target_dimensions().y);
+        set_height(rel_height * get_effective_frame_renderer()->get_target_dimensions().y);
 }
 
 const vector2f& region::get_dimensions() const {
@@ -780,10 +780,10 @@ bool region::is_loaded() const {
     return is_loaded_;
 }
 
-utils::observer_ptr<const frame_renderer> region::get_top_level_frame_renderer() const {
+utils::observer_ptr<const frame_renderer> region::get_effective_frame_renderer() const {
     if (!parent_)
         return get_manager().get_root().observer_from_this();
-    return parent_->get_top_level_frame_renderer();
+    return parent_->get_effective_frame_renderer();
 }
 
 void region::notify_visible() {

--- a/src/gui_region.cpp
+++ b/src/gui_region.cpp
@@ -25,9 +25,9 @@ region::region(utils::control_block& block, manager& mgr, const region_core_attr
         set_virtual_();
 
     if (attr.parent)
-        set_name_and_parent_(attr.name, attr.parent);
-    else
-        set_name_(attr.name);
+        set_parent_(attr.parent);
+
+    set_name_(attr.name);
 
     initialize_(*this, attr);
 }
@@ -325,29 +325,14 @@ void region::set_parent_(utils::observer_ptr<frame> parent) {
         return;
     }
 
-    if (parent_ != parent) {
-        parent_ = std::move(parent);
-
-        if (!is_virtual_)
-            notify_borders_need_update();
-    }
-}
-
-void region::set_name_and_parent_(const std::string& name, utils::observer_ptr<frame> parent) {
-    if (parent == observer_from_this()) {
-        gui::out << gui::error << "gui::" << type_.back() << ": Cannot call set_parent(this)."
-                 << std::endl;
-        return;
-    }
-
-    if (parent_ == parent && name == name_)
+    if (parent_ == parent)
         return;
 
     parent_ = std::move(parent);
-    set_name_(name);
 
-    if (!is_virtual_)
+    if (!is_virtual()) {
         notify_borders_need_update();
+    }
 }
 
 utils::owner_ptr<region> region::release_from_parent() {

--- a/src/gui_root.cpp
+++ b/src/gui_root.cpp
@@ -555,7 +555,14 @@ void root::on_mouse_moved_(const vector2f& movement, const vector2f& mouse_pos) 
         dragged_frame_->fire_script("OnDragMove", data);
     }
 
-    if (!hovered_frame_) {
+    if (hovered_frame_) {
+        event_data data;
+        data.add(movement.x);
+        data.add(movement.y);
+        data.add(mouse_pos.x);
+        data.add(mouse_pos.y);
+        hovered_frame_->fire_script("OnMouseMove", data);
+    } else {
         // Forward to the world
         world_input_dispatcher_.on_mouse_moved(movement, mouse_pos);
     }

--- a/src/gui_scroll_frame.cpp
+++ b/src/gui_scroll_frame.cpp
@@ -74,6 +74,7 @@ void scroll_frame::copy_from(const region& obj) {
 
 void scroll_frame::set_scroll_child(utils::owner_ptr<frame> obj) {
     if (scroll_child_) {
+        // TODO: is this really needed now?
         scroll_child_->set_frame_renderer(nullptr);
         clear_strata_list_();
     } else if (!is_virtual() && !scroll_texture_) {


### PR DESCRIPTION
Multiple fixes:
 - Fixed `edit_box` missing the key repeat events.
 - Added the `OnMouseMove` frame event.
 - Added missing `enableMouseMove` and `enableMouseClick` in layout files.
 - Fixed propagation of frame_strata when inheriting strata from parent.
 - Removed `frame_strata::parent`; now the frame's strata is an `std::optional`, and `nullopt` means "inherit from parent"
 - Switched `frame_renderer` to use a single sorted vector instead of nested maps(!).
 - Fixed `OnSizeChanged` triggering only inside `frame::update()` rather than immediately
 - Fixed Lua parsing errors not reported