### PR TITLE
Clean up `region` class

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,13 +587,13 @@ gui::root& root = manager->get_root();
 // NB: observer_ptr is a lightweight, non-owning smart pointer (vaguely similar to std::weak_ptr).
 utils::observer_ptr<gui::frame> frame =
     root.create_root_frame<gui::frame>("FPSCounter");
-frame->set_point(gui::point::TOP_LEFT);
-frame->set_point(gui::point::BOTTOM_RIGHT);
+frame->set_anchor(gui::point::TOP_LEFT);
+frame->set_anchor(gui::point::BOTTOM_RIGHT);
 
 // Create the FontString as a child region of the frame.
 utils::observer_ptr<gui::font_string> text =
     frame->create_layered_region<gui::font_string>(gui::layer::ARTWORK, "$parentText");
-text->set_point(gui::point::BOTTOM_RIGHT, gui::vector2f{-5, -5});
+text->set_anchor(gui::point::BOTTOM_RIGHT, gui::vector2f{-5, -5});
 text->set_font("interface/fonts/main.ttf", 12);
 text->set_alignment_x(gui::alignment_x::RIGHT);
 text->set_alignment_y(gui::alignment_y::BOTTOM);

--- a/bin/interface/scroll_test/addon.lua
+++ b/bin/interface/scroll_test/addon.lua
@@ -29,8 +29,8 @@ function ScrollTest:init_root_folder()
     rootFolder.folderNum = 0
 
     rootFolder:set_text("/")
-    rootFolder:set_point("RIGHT", self.Splitter.FolderFrame.Scroll, "RIGHT", -5, 0)
-    rootFolder:set_point("TOP_LEFT", self.Splitter.FolderFrame.Scroll, "TOP_LEFT", 5, 5)
+    rootFolder:set_anchor("RIGHT", self.Splitter.FolderFrame.Scroll, "RIGHT", -5, 0)
+    rootFolder:set_anchor("TOP_LEFT", self.Splitter.FolderFrame.Scroll, "TOP_LEFT", 5, 5)
 
     rootFolder.Develop.Plus:hide()
 
@@ -68,9 +68,9 @@ function ScrollTest:init_root_folder()
 
         if rootFolder.lastFolder then
             rootFolder.lastFolder.nextFolder = folderButton
-            folderButton:set_point("TOP_LEFT", rootFolder.lastFolder, "BOTTOM_LEFT")
+            folderButton:set_anchor("TOP_LEFT", rootFolder.lastFolder, "BOTTOM_LEFT")
         else
-            folderButton:set_point("TOP_LEFT", rootFolder, "BOTTOM_LEFT", 16, 0)
+            folderButton:set_anchor("TOP_LEFT", rootFolder, "BOTTOM_LEFT", 16, 0)
         end
 
         self.folders[self.lastID] = folderButton
@@ -137,9 +137,9 @@ function ScrollTest:develop_folder(id, toggle)
 
             if parentFolder.lastFolder then
                 parentFolder.lastFolder.nextFolder = folderButton
-                folderButton:set_point("TOP_LEFT", parentFolder.lastFolder, "BOTTOM_LEFT")
+                folderButton:set_anchor("TOP_LEFT", parentFolder.lastFolder, "BOTTOM_LEFT")
             else
-                folderButton:set_point("TOP_LEFT", parentFolder, "BOTTOM_LEFT", 16, 0)
+                folderButton:set_anchor("TOP_LEFT", parentFolder, "BOTTOM_LEFT", 16, 0)
             end
 
             self.folders[self.lastID] = folderButton
@@ -163,7 +163,7 @@ function ScrollTest:develop_folder(id, toggle)
         end
 
         if parentFolder.nextFolder then
-            parentFolder.nextFolder:set_point(
+            parentFolder.nextFolder:set_anchor(
                 "TOP_LEFT", parentFolder.lastFolder, "BOTTOM_LEFT",
                 -16*(parentFolder.lastFolder.level - parentFolder.nextFolder.level), 0
             )
@@ -176,7 +176,7 @@ function ScrollTest:develop_folder(id, toggle)
         parentFolder.developed = false
 
         if (parentFolder.lastFolder.nextFolder) then
-            parentFolder.lastFolder.nextFolder:set_point("TOP_LEFT", parentFolder, "BOTTOM_LEFT")
+            parentFolder.lastFolder.nextFolder:set_anchor("TOP_LEFT", parentFolder, "BOTTOM_LEFT")
             parentFolder.nextFolder = parentFolder.lastFolder.nextFolder
         end
 
@@ -292,9 +292,9 @@ function ScrollTest:set_folder(id)
         fileButton:get_normal_font_object():set_word_wrap(false)
 
         if self.lastFile then
-            fileButton:set_point("TOP_LEFT", self.lastFile, "BOTTOM_LEFT")
+            fileButton:set_anchor("TOP_LEFT", self.lastFile, "BOTTOM_LEFT")
         else
-            fileButton:set_point("TOP_LEFT", self.Splitter.FileFrame.Scroll, "TOP_LEFT", 5, 5)
+            fileButton:set_anchor("TOP_LEFT", self.Splitter.FileFrame.Scroll, "TOP_LEFT", 5, 5)
         end
 
         fileButton.IconFrame.Icon:set_texture("|icons.png")

--- a/bin/interface/scroll_test/addon.xml
+++ b/bin/interface/scroll_test/addon.xml
@@ -99,8 +99,8 @@
                 </Anchors>
                 <Scripts>
                     <OnLoad>
-                        self.ThumbTexture:set_point("TOP", self, "TOP");
-                        self.ThumbTexture:set_point("BOTTOM", self, "BOTTOM");
+                        self.ThumbTexture:set_anchor("TOP", self, "TOP");
+                        self.ThumbTexture:set_anchor("BOTTOM", self, "BOTTOM");
                     </OnLoad>
                 </Scripts>
                 <Frames>

--- a/bin/interface/scroll_test/templates.xml
+++ b/bin/interface/scroll_test/templates.xml
@@ -10,7 +10,7 @@
                 </Offset>
             </Anchor>
         </Anchors>
-        <NormalText font="interface/fonts/main.ttf" fontHeight="11" setAllPoints="false" alignX="LEFT">
+        <NormalText font="interface/fonts/main.ttf" fontHeight="11" setAllAnchors="false" alignX="LEFT">
             <Anchors>
                 <Anchor point="LEFT" relativeTo="$parentIconFrame" relativePoint="RIGHT">
                     <Offset>
@@ -36,7 +36,7 @@
                 </Anchors>
                 <Layers>
                     <Layer>
-                        <Texture name="$parentIcon" setAllPoints="true"/>
+                        <Texture name="$parentIcon" setAllAnchors="true"/>
                     </Layer>
                 </Layers>
             </Frame>
@@ -50,7 +50,7 @@
         <Anchors>
             <Anchor point="RIGHT"/>
         </Anchors>
-        <NormalText font="interface/fonts/main.ttf" fontHeight="11" setAllPoints="false" alignX="LEFT">
+        <NormalText font="interface/fonts/main.ttf" fontHeight="11" setAllAnchors="false" alignX="LEFT">
             <Anchors>
                 <Anchor point="LEFT" relativeTo="$parentIconFrame" relativePoint="RIGHT">
                     <Offset>
@@ -77,10 +77,10 @@
                 </Anchors>
                 <Layers>
                     <Layer>
-                        <Texture name="$parentPlus" file="|icons.png" setAllPoints="true">
+                        <Texture name="$parentPlus" file="|icons.png" setAllAnchors="true">
                             <TexCoords left="0" right="0.125" top="0.0" bottom="1.0"/>
                         </Texture>
-                        <Texture name="$parentMinus" file="|icons.png" hidden="true" setAllPoints="true">
+                        <Texture name="$parentMinus" file="|icons.png" hidden="true" setAllAnchors="true">
                             <TexCoords left="0.125" right="0.25" top="0.0" bottom="1.0"/>
                         </Texture>
                     </Layer>
@@ -100,7 +100,7 @@
                 </Anchors>
                 <Layers>
                     <Layer>
-                        <Texture name="$parentFolder" file="|icons.png" setAllPoints="true">
+                        <Texture name="$parentFolder" file="|icons.png" setAllAnchors="true">
                             <TexCoords left="0.25" right="0.375" top="0.0" bottom="1.0"/>
                         </Texture>
                     </Layer>

--- a/bin/interface/slider_test/addon.xml
+++ b/bin/interface/slider_test/addon.xml
@@ -38,7 +38,7 @@
                     </Anchor>
                 </Anchors>
                 <Frames>
-                    <Frame name="$parentColorZone" setAllPoints="true">
+                    <Frame name="$parentColorZone" setAllAnchors="true">
                         <Backdrop edgeFile="|border_2px.png">
                             <BackgroundInsets>
                                 <AbsInset left="2" right="2" top="2" bottom="2"/>

--- a/bin/interface/slider_test/templates.xml
+++ b/bin/interface/slider_test/templates.xml
@@ -89,7 +89,7 @@
                                 </Offset>
                             </Anchor>
                         </Anchors>
-                        <NormalText font="interface/fonts/main.ttf" fontHeight="11" setAllPoints="false">
+                        <NormalText font="interface/fonts/main.ttf" fontHeight="11" setAllAnchors="false">
                             <Anchors>
                                 <Anchor point="CENTER"/>
                             </Anchors>

--- a/bin/interface/statusbar_test/addon.xml
+++ b/bin/interface/statusbar_test/addon.xml
@@ -59,7 +59,7 @@
                 self.timer = self.update_time;
                 self.total_fps = 0;
                 self.frames = 0;
-                FontstringTestFrameText:set_point("BOTTOM_RIGHT", self, "TOP_RIGHT", -2, -5);
+                FontstringTestFrameText:set_anchor("BOTTOM_RIGHT", self, "TOP_RIGHT", -2, -5);
             </OnLoad>
             <OnUpdate>
                 if (arg1 == 0) then arg1 = 0.1; end

--- a/bin/interface/statusbar_test/addon.xml
+++ b/bin/interface/statusbar_test/addon.xml
@@ -37,7 +37,7 @@
         </Scripts>
         <Layers>
             <Layer level="HIGHLIGHT">
-                <FontString name="$parentText" font="interface/fonts/main.ttf" fontHeight="11" outline="NORMAL" text="Zoom x1.0" setAllPoints="true"/>
+                <FontString name="$parentText" font="interface/fonts/main.ttf" fontHeight="11" outline="NORMAL" text="Zoom x1.0" setAllAnchors="true"/>
             </Layer>
         </Layers>
     </StatusBar>
@@ -85,7 +85,7 @@
         </Scripts>
         <Layers>
             <Layer level="HIGHLIGHT">
-                <Texture name="$parentBorder" file="|bar_outline.png" setAllPoints="true"/>
+                <Texture name="$parentBorder" file="|bar_outline.png" setAllAnchors="true"/>
             </Layer>
         </Layers>
     </StatusBar>

--- a/changelog.txt
+++ b/changelog.txt
@@ -120,6 +120,9 @@ Other changes:
  - gui: renamed anchor_point to point
  - gui: renamed register_for_drag to enable_drag
  - gui: renamed get_object_type to get_region_type
+ - gui: renamed clear_all_points to clear_all_anchors
+ - gui: renamed [get/set/modify]_point to [get/set/modify]_anchor
+ - gui: renamed any function of the form "get_num_[...]()" into "get_[...]_count()"
  - gui: removed Frame:on from Lua API (instead, call scripts directly, e.g.: frame:on_update())
  - gui: removed the sprite class
  - gui: removed region::get_base()

--- a/changelog.txt
+++ b/changelog.txt
@@ -119,6 +119,7 @@ Other changes:
  - gui: renamed justifyH to alignX, justifyV to alignY
  - gui: renamed anchor_point to point
  - gui: renamed register_for_drag to enable_drag
+ - gui: renamed get_object_type to get_region_type
  - gui: removed Frame:on from Lua API (instead, call scripts directly, e.g.: frame:on_update())
  - gui: removed the sprite class
  - gui: removed region::get_base()
@@ -138,6 +139,7 @@ Other changes:
  - gui: removed frame::is_in_frame; use is_in_region instead
  - gui: removed frame::register_all_events and unregister_all_events
  - gui: removed event class; generic events are now only using event_data
+ - gui: removed get_frame_type, use get_region_type instead
  - gui: edit_box::set_text_insets now takes a single bounds2f argument
  - gui: frame::on_script now takes the full script name ("OnUpdate" vs "Update")
  - gui: frame::on_script now takes a 'const event_data&' instead of an 'event*' argument

--- a/changelog.txt
+++ b/changelog.txt
@@ -123,6 +123,7 @@ Other changes:
  - gui: renamed clear_all_points to clear_all_anchors
  - gui: renamed [get/set/modify]_point to [get/set/modify]_anchor
  - gui: renamed any function of the form "get_num_[...]()" into "get_[...]_count()"
+ - gui: renamed set_all_points/clear_all_points to set_all_anchors/clear_all_anchors
  - gui: removed Frame:on from Lua API (instead, call scripts directly, e.g.: frame:on_update())
  - gui: removed the sprite class
  - gui: removed region::get_base()

--- a/examples/common/examples_common.cpp
+++ b/examples/common/examples_common.cpp
@@ -111,15 +111,15 @@ void examples_setup_gui(gui::manager& manager) {
     // Create a root frame.
     utils::observer_ptr<gui::frame> fps_frame;
     fps_frame = root.create_root_frame<gui::frame>("FPSCounter");
-    fps_frame->set_point(gui::point::top_left);
-    fps_frame->set_point(
+    fps_frame->set_anchor(gui::point::top_left);
+    fps_frame->set_anchor(
         gui::point::bottom_right, "FontstringTestFrameText", gui::point::top_right);
 
     // Create a font_string in the frame.
     utils::observer_ptr<gui::font_string> fps_text;
     fps_text =
         fps_frame->create_layered_region<gui::font_string>(gui::layer::artwork, "$parentText");
-    fps_text->set_point(gui::point::bottom_right, gui::vector2f(0, -5));
+    fps_text->set_anchor(gui::point::bottom_right, gui::vector2f(0, -5));
     fps_text->set_font("interface/fonts/main.ttf", 15);
     fps_text->set_alignment_y(gui::alignment_y::bottom);
     fps_text->set_alignment_x(gui::alignment_x::right);

--- a/examples/opengl-sdl-emscripten/main.cpp
+++ b/examples/opengl-sdl-emscripten/main.cpp
@@ -57,7 +57,7 @@ void main_loop(void* type_erased_data) try {
     }
 
     // Reset batch count (for analytics only, optional)
-    context.manager->get_renderer().reset_batch_count();
+    context.manager->get_renderer().reset_counters();
 
     // Update the gui
     SDL_GL_MakeCurrent(context.window, context.gl_context);

--- a/examples/opengl-sdl-emscripten/main.cpp
+++ b/examples/opengl-sdl-emscripten/main.cpp
@@ -57,7 +57,7 @@ void main_loop(void* type_erased_data) try {
     }
 
     // Reset batch count (for analytics only, optional)
-    manager->get_renderer().reset_batch_count();
+    context.manager->get_renderer().reset_batch_count();
 
     // Update the gui
     SDL_GL_MakeCurrent(context.window, context.gl_context);

--- a/examples/opengl-sdl-emscripten/main.cpp
+++ b/examples/opengl-sdl-emscripten/main.cpp
@@ -56,6 +56,9 @@ void main_loop(void* type_erased_data) try {
         return;
     }
 
+    // Reset batch count (for analytics only, optional)
+    manager->get_renderer().reset_batch_count();
+
     // Update the gui
     SDL_GL_MakeCurrent(context.window, context.gl_context);
     context.manager->update_ui(context.delta);

--- a/examples/opengl-sdl/main.cpp
+++ b/examples/opengl-sdl/main.cpp
@@ -146,7 +146,7 @@ int main(int argc, char* argv[]) {
             }
 
             // Reset batch count (for analytics only, optional)
-            manager->get_renderer().reset_batch_count();
+            manager->get_renderer().reset_counters();
 
             // Update the gui
             SDL_GL_MakeCurrent(window.get(), gl_context.context);

--- a/examples/opengl-sdl/main.cpp
+++ b/examples/opengl-sdl/main.cpp
@@ -145,6 +145,9 @@ int main(int argc, char* argv[]) {
                 continue;
             }
 
+            // Reset batch count (for analytics only, optional)
+            manager->get_renderer().reset_batch_count();
+
             // Update the gui
             SDL_GL_MakeCurrent(window.get(), gl_context.context);
             manager->update_ui(delta);

--- a/examples/opengl-sfml/main.cpp
+++ b/examples/opengl-sfml/main.cpp
@@ -102,7 +102,7 @@ int main(int argc, char* argv[]) {
             }
 
             // Reset batch count (for analytics only, optional)
-            manager->get_renderer().reset_batch_count();
+            manager->get_renderer().reset_counters();
 
             // Update the gui
             manager->update_ui(delta);

--- a/examples/opengl-sfml/main.cpp
+++ b/examples/opengl-sfml/main.cpp
@@ -101,6 +101,9 @@ int main(int argc, char* argv[]) {
                 continue;
             }
 
+            // Reset batch count (for analytics only, optional)
+            manager->get_renderer().reset_batch_count();
+
             // Update the gui
             manager->update_ui(delta);
 

--- a/examples/sdl-emscripten/main.cpp
+++ b/examples/sdl-emscripten/main.cpp
@@ -55,7 +55,7 @@ void main_loop(void* type_erased_data) try {
     }
 
     // Reset batch count (for analytics only, optional)
-    manager->get_renderer().reset_batch_count();
+    context.manager->get_renderer().reset_batch_count();
 
     // Update the gui
     context.manager->update_ui(context.delta);

--- a/examples/sdl-emscripten/main.cpp
+++ b/examples/sdl-emscripten/main.cpp
@@ -54,6 +54,9 @@ void main_loop(void* type_erased_data) try {
         return;
     }
 
+    // Reset batch count (for analytics only, optional)
+    manager->get_renderer().reset_batch_count();
+
     // Update the gui
     context.manager->update_ui(context.delta);
 

--- a/examples/sdl-emscripten/main.cpp
+++ b/examples/sdl-emscripten/main.cpp
@@ -55,7 +55,7 @@ void main_loop(void* type_erased_data) try {
     }
 
     // Reset batch count (for analytics only, optional)
-    context.manager->get_renderer().reset_batch_count();
+    context.manager->get_renderer().reset_counters();
 
     // Update the gui
     context.manager->update_ui(context.delta);

--- a/examples/sdl/main.cpp
+++ b/examples/sdl/main.cpp
@@ -116,6 +116,9 @@ int main(int argc, char* argv[]) {
                 continue;
             }
 
+            // Reset batch count (for analytics only, optional)
+            manager->get_renderer().reset_batch_count();
+
             // Update the gui
             manager->update_ui(delta);
 

--- a/examples/sdl/main.cpp
+++ b/examples/sdl/main.cpp
@@ -117,7 +117,7 @@ int main(int argc, char* argv[]) {
             }
 
             // Reset batch count (for analytics only, optional)
-            manager->get_renderer().reset_batch_count();
+            manager->get_renderer().reset_counters();
 
             // Update the gui
             manager->update_ui(delta);

--- a/examples/sfml/main.cpp
+++ b/examples/sfml/main.cpp
@@ -86,7 +86,7 @@ int main(int argc, char* argv[]) {
             }
 
             // Reset batch count (for analytics only, optional)
-            manager->get_renderer().reset_batch_count();
+            manager->get_renderer().reset_counters();
 
             // Update the gui
             manager->update_ui(delta);

--- a/examples/sfml/main.cpp
+++ b/examples/sfml/main.cpp
@@ -85,6 +85,9 @@ int main(int argc, char* argv[]) {
                 continue;
             }
 
+            // Reset batch count (for analytics only, optional)
+            manager->get_renderer().reset_batch_count();
+
             // Update the gui
             manager->update_ui(delta);
 

--- a/impl/gui/gl/src/gui_gl_vertex_cache.cpp
+++ b/impl/gui/gl/src/gui_gl_vertex_cache.cpp
@@ -87,6 +87,7 @@ void vertex_cache::update_indices(const std::uint32_t* vertex_indices, std::size
     }
 
     current_size_index_ = num_indices;
+    num_vertex_         = current_size_index_;
 }
 
 void vertex_cache::update_indices_if_grow(
@@ -96,6 +97,7 @@ void vertex_cache::update_indices_if_grow(
     } else {
         // Cheap resize, do not update indices
         current_size_index_ = num_indices;
+        num_vertex_         = current_size_index_;
     }
 }
 

--- a/impl/gui/sfml/src/gui_sfml_renderer.cpp
+++ b/impl/gui/sfml/src/gui_sfml_renderer.cpp
@@ -142,7 +142,7 @@ void renderer::render_cache_(
     if (sf_mat)
         state.texture = sf_mat->get_texture();
     state.transform = to_sfml(model_transform);
-    current_sfml_target_->draw(sf_cache.get_impl(), 0, sf_cache.get_num_vertex(), state);
+    current_sfml_target_->draw(sf_cache.get_impl(), 0, sf_cache.get_vertex_count(), state);
 #else
     throw gui::exception("gui::sfml::renderer", "SFML does not support vertex caches.");
 #endif

--- a/impl/gui/sfml/src/gui_sfml_vertex_cache.cpp
+++ b/impl/gui/sfml/src/gui_sfml_vertex_cache.cpp
@@ -55,10 +55,6 @@ void vertex_cache::update(const vertex* vertex_data, std::size_t num_vertex) {
     }
 }
 
-std::size_t vertex_cache::get_num_vertex() const {
-    return num_vertex_;
-}
-
 const sf::VertexBuffer& vertex_cache::get_impl() const {
     return buffer_;
 }

--- a/include/lxgui/gui_animated_texture.hpp
+++ b/include/lxgui/gui_animated_texture.hpp
@@ -15,9 +15,9 @@ class renderer;
  * \details This object contains an animated texture taken from a file.
  */
 class animated_texture : public layered_region {
+public:
     using base = layered_region;
 
-public:
     /// Constructor.
     explicit animated_texture(
         utils::control_block& block, manager& mgr, const region_core_attributes& attr);
@@ -133,6 +133,8 @@ private:
 
     void update_tex_coords_();
     void update_borders_() override;
+
+    const std::vector<std::string>& get_type_list_() const override;
 
     std::string file_;
 

--- a/include/lxgui/gui_atlas.hpp
+++ b/include/lxgui/gui_atlas.hpp
@@ -181,7 +181,7 @@ public:
      * \brief Return the number of pages in this atlas.
      * \return The number of pages in this atlas
      */
-    std::size_t get_num_pages() const;
+    std::size_t get_page_count() const;
 
 protected:
     /**

--- a/include/lxgui/gui_button.hpp
+++ b/include/lxgui/gui_button.hpp
@@ -41,9 +41,9 @@ class font_string;
  * - `OnDisable`: Triggered by button::disable.
  */
 class button : public frame {
+public:
     using base = frame;
 
-public:
     enum class state { up, down, disabled };
 
     /// Constructor.
@@ -341,6 +341,8 @@ public:
 protected:
     void parse_attributes_(const layout_node& node) override;
     void parse_all_nodes_before_children_(const layout_node& node) override;
+
+    const std::vector<std::string>& get_type_list_() const override;
 
     state state_               = state::up;
     bool  is_highlighted_      = false;

--- a/include/lxgui/gui_check_button.hpp
+++ b/include/lxgui/gui_check_button.hpp
@@ -13,9 +13,9 @@ namespace lxgui::gui {
  * additional special textures for the check sign.
  */
 class check_button : public button {
+public:
     using base = button;
 
-public:
     /// Constructor.
     explicit check_button(
         utils::control_block& block, manager& mgr, const frame_core_attributes& attr);
@@ -112,6 +112,8 @@ public:
 
 protected:
     void parse_all_nodes_before_children_(const layout_node& node) override;
+
+    const std::vector<std::string>& get_type_list_() const override;
 
     bool is_checked_ = false;
 

--- a/include/lxgui/gui_edit_box.hpp
+++ b/include/lxgui/gui_edit_box.hpp
@@ -141,14 +141,14 @@ public:
     /**
      * \brief Returns the current position of the cursor.
      * \return The position of the cursor (0: before first character,
-                get_num-letters(): after last character).
+                get_letter_count(): after last character).
     */
     std::size_t get_cursor_position() const;
 
     /**
      * \brief Moves the cursor to a chosen position.
      * \param pos The new cursor position (0: before first character,
-                     get_num-letters(): after last character).
+                     get_letter_count(): after last character).
     */
     void set_cursor_position(std::size_t pos);
 
@@ -168,7 +168,7 @@ public:
      * \brief Returns the number of letters in the content.
      * \return The number of letters in the content
      */
-    std::size_t get_num_letters() const;
+    std::size_t get_letter_count() const;
 
     /**
      * \brief Sets the carret's blink speed.

--- a/include/lxgui/gui_edit_box.hpp
+++ b/include/lxgui/gui_edit_box.hpp
@@ -60,9 +60,9 @@ class texture;
  * followed by `OnTextChanged`.
  */
 class edit_box : public frame {
+public:
     using base = frame;
 
-public:
     /// Constructor.
     explicit edit_box(utils::control_block& block, manager& mgr, const frame_core_attributes& attr);
 
@@ -348,6 +348,8 @@ protected:
     void parse_all_nodes_before_children_(const layout_node& node) override;
     void parse_font_string_node_(const layout_node& node);
     void parse_text_insets_node_(const layout_node& node);
+
+    const std::vector<std::string>& get_type_list_() const override;
 
     void create_font_string_();
     void create_highlight_();

--- a/include/lxgui/gui_event_data.hpp
+++ b/include/lxgui/gui_event_data.hpp
@@ -36,7 +36,7 @@ public:
 
     /**
      * \brief Returns a parameter of this event.
-     * \param index The index of the parameter (see get_num_param())
+     * \param index The index of the parameter (see get_param_count())
      * \return A parameter of this event
      */
     const utils::variant& get(std::size_t index) const {
@@ -47,7 +47,7 @@ public:
 
     /**
      * \brief Returns a parameter of this event.
-     * \param index The index of the parameter (see get_num_param())
+     * \param index The index of the parameter (see get_param_count())
      * \return A parameter of this event
      */
     utils::variant& get(std::size_t index) {
@@ -58,7 +58,7 @@ public:
 
     /**
      * \brief Returns a parameter of this event.
-     * \param index The index of the parameter (see get_num_param())
+     * \param index The index of the parameter (see get_param_count())
      * \return A parameter of this event
      */
     template<typename T>
@@ -68,7 +68,7 @@ public:
 
     /**
      * \brief Returns a parameter of this event.
-     * \param index The index of the parameter (see get_num_param())
+     * \param index The index of the parameter (see get_param_count())
      * \return A parameter of this event
      */
     template<typename T>
@@ -80,7 +80,7 @@ public:
      * \brief Returns the number of parameters.
      * \return The number of parameters
      */
-    std::size_t get_num_param() const {
+    std::size_t get_param_count() const {
         return arg_list_.size();
     }
 

--- a/include/lxgui/gui_font_string.hpp
+++ b/include/lxgui/gui_font_string.hpp
@@ -32,9 +32,9 @@ namespace lxgui::gui {
  * in the specified area.
  */
 class font_string : public layered_region {
+public:
     using base = layered_region;
 
-public:
     /// Constructor.
     explicit font_string(
         utils::control_block& block, manager& mgr, const region_core_attributes& attr);
@@ -308,6 +308,8 @@ public:
 private:
     void parse_attributes_(const layout_node& node) override;
     void parse_shadow_node_(const layout_node& node);
+
+    const std::vector<std::string>& get_type_list_() const override;
 
     void create_text_object_();
 

--- a/include/lxgui/gui_frame.hpp
+++ b/include/lxgui/gui_frame.hpp
@@ -248,9 +248,9 @@ using script_list_view = script_signal::slot_list_view;
  * child frames, and all the layered regions of the virtual frame.
  */
 class frame : public region {
+public:
     using base = region;
 
-public:
     /**
      * \brief Type of the frame child list (internal).
      * \note Constraints on the choice container type:
@@ -1565,6 +1565,8 @@ protected:
     virtual void parse_layers_node_(const layout_node& node);
     virtual void parse_frames_node_(const layout_node& node);
     virtual void parse_scripts_node_(const layout_node& node);
+
+    const std::vector<std::string>& get_type_list_() const override;
 
     utils::observer_ptr<layered_region>
     parse_region_(const layout_node& node, const std::string& layer_name, const std::string& type);

--- a/include/lxgui/gui_frame.hpp
+++ b/include/lxgui/gui_frame.hpp
@@ -819,36 +819,36 @@ public:
     /**
      * \brief Returns the number of children of this frame.
      * \return The number of children of this frame
-     * \note If only an approximate number is acceptable, use get_rough_num_children(),
+     * \note If only an approximate number is acceptable, use get_child_count_upper_bound(),
      * which is faster.
      */
-    std::size_t get_num_children() const;
+    std::size_t get_child_count() const;
 
     /**
      * \brief Returns the approximate number of children of this frame.
      * \return The approximate number of children of this frame
      * \note The returned number is an *upper bound* on the actual number of children.
      * This can be used to reserve enough space for memory allocations.
-     * If the exact number of children is required, use get_num_children().
+     * If the exact number of children is required, use get_child_count().
      */
-    std::size_t get_rough_num_children() const;
+    std::size_t get_child_count_upper_bound() const;
 
     /**
-     * \brief Returns the number of regions of this frame.
-     * \return The number of regions of this frame
-     * \note If only an approximate number is acceptable, use get_rough_num_regions(),
+     * \brief Returns the number of layered regions of this frame.
+     * \return The number of layered regions of this frame
+     * \note If only an approximate number is acceptable, use get_layered_region_count_upper_bound(),
      * which is faster.
      */
-    std::size_t get_num_regions() const;
+    std::size_t get_layered_region_count() const;
 
     /**
      * \brief Returns the approximate number of regions of this frame.
      * \return The approximate number of regions of this frame
      * \note The returned number is an *upper bound* on the actual number of regions.
      * This can be used to reserve enough space for memory allocations.
-     * If the exact number of regions is required, use get_num_regions().
+     * If the exact number of regions is required, use get_layered_region_count().
      */
-    std::size_t get_rough_num_regions() const;
+    std::size_t get_layered_region_count_upper_bound() const;
 
     /**
      * \brief Returns this frame's scale.

--- a/include/lxgui/gui_frame.hpp
+++ b/include/lxgui/gui_frame.hpp
@@ -1395,20 +1395,6 @@ public:
     void stop_sizing();
 
     /**
-     * \brief shows this region.
-     * \note Its parent must be shown for it to appear on
-     * the screen.
-     */
-    void show() override;
-
-    /**
-     * \brief hides this region.
-     * \note All its children won't be visible on the screen
-     * anymore, even if they are still marked as shown.
-     */
-    void hide() override;
-
-    /**
      * \brief Enables automatic focus when this frame is shown or raised.
      * \param enable 'true' to enable auto focus
      */

--- a/include/lxgui/gui_frame.hpp
+++ b/include/lxgui/gui_frame.hpp
@@ -1053,15 +1053,15 @@ public:
      *
      * \note This overload enables taking handler scripts with a `self` parameter of type other than
      * \ref frame, for example:
-     * \begin_code{cpp}
+     * \code{cpp}
      * add_script([](button& self, const event_data& data) { ... });
-     * \end_code
+     * \endcode
      * For maximum safety, by default this is done using a `dynamic_cast`, so that incorrect types
      * will be reported. However this has a cost; if you are sure of the type and want to bypass
      * this cost, just supply the `self` type as the first template argument to this function:
-     * \begin_code{cpp}
+     * \code{cpp}
      * add_script<button>([](button& self, const event_data& data) { ... });
-     * \end_code
+     * \endcode
      */
     template<typename DerivedType = void, typename Function>
     utils::connection add_script(
@@ -1161,15 +1161,15 @@ public:
      *
      * \note This overload enables taking handler scripts with a `self` parameter of type other than
      * \ref frame, for example:
-     * \begin_code{cpp}
+     * \code{cpp}
      * add_script([](button& self, const event_data& data) { ... });
-     * \end_code
+     * \endcode
      * For maximum safety, by default this is done using a `dynamic_cast`, so that incorrect types
      * will be reported. However this has a cost; if you are sure of the type and want to bypass
      * this cost, just supply the `self` type as the first template argument to this function:
-     * \begin_code{cpp}
+     * \code{cpp}
      * add_script<button>([](button& self, const event_data& data) { ... });
-     * \end_code
+     * \endcode
      */
     template<typename DerivedType = void, typename Function>
     utils::connection set_script(

--- a/include/lxgui/gui_frame.hpp
+++ b/include/lxgui/gui_frame.hpp
@@ -994,6 +994,8 @@ public:
      */
     utils::connection add_script(
         const std::string& script_name, std::string content, script_info info = script_info{}) {
+        if (!check_script_(script_name))
+            return {};
         return define_script_(script_name, content, true, info);
     }
 
@@ -1013,6 +1015,8 @@ public:
         const std::string&      script_name,
         sol::protected_function handler,
         script_info             info = script_info{}) {
+        if (!check_script_(script_name))
+            return {};
         return define_script_(script_name, std::move(handler), true, info);
     }
 
@@ -1030,6 +1034,8 @@ public:
      */
     utils::connection add_script(
         const std::string& script_name, script_function handler, script_info info = script_info{}) {
+        if (!check_script_(script_name))
+            return {};
         return define_script_(script_name, std::move(handler), true, info);
     }
 
@@ -1096,6 +1102,8 @@ public:
      */
     utils::connection set_script(
         const std::string& script_name, std::string content, script_info info = script_info{}) {
+        if (!check_script_(script_name))
+            return {};
         return define_script_(script_name, content, false, info);
     }
 
@@ -1115,6 +1123,8 @@ public:
         const std::string&      script_name,
         sol::protected_function handler,
         script_info             info = script_info{}) {
+        if (!check_script_(script_name))
+            return {};
         return define_script_(script_name, std::move(handler), false, info);
     }
 
@@ -1132,6 +1142,8 @@ public:
      */
     utils::connection set_script(
         const std::string& script_name, script_function handler, script_info info = script_info{}) {
+        if (!check_script_(script_name))
+            return {};
         return define_script_(script_name, std::move(handler), false, info);
     }
 
@@ -1584,6 +1596,8 @@ protected:
      * \note Default is nullptr.
      */
     void set_parent_(utils::observer_ptr<frame> parent) override;
+
+    bool check_script_(const std::string& script_name) const;
 
     utils::connection define_script_(
         const std::string& script_name,

--- a/include/lxgui/gui_frame.hpp
+++ b/include/lxgui/gui_frame.hpp
@@ -793,12 +793,6 @@ public:
     backdrop& get_or_create_backdrop();
 
     /**
-     * \brief Returns this frame's type.
-     * \return This frame's type (Frame, Slider, ...)
-     */
-    const std::string& get_frame_type() const;
-
-    /**
      * \brief Returns this frame's absolute hit rect insets.
      * \return This frame's absolute hit rect insets
      */

--- a/include/lxgui/gui_layered_region.hpp
+++ b/include/lxgui/gui_layered_region.hpp
@@ -42,26 +42,6 @@ public:
     utils::owner_ptr<region> release_from_parent() override;
 
     /**
-     * \brief shows this region.
-     * \note Its parent must be shown for it to appear on
-     * the screen.
-     */
-    void show() override;
-
-    /**
-     * \brief hides this region.
-     * \note All its children won't be visible on the screen
-     * anymore, even if they are still marked as shown.
-     */
-    void hide() override;
-
-    /**
-     * \brief Checks if this region can be seen on the screen.
-     * \return 'true' if this region can be seen on the screen
-     */
-    bool is_visible() const override;
-
-    /**
      * \brief Returns this layered_region's draw layer.
      * \return this layered_region's draw layer
      */

--- a/include/lxgui/gui_layered_region.hpp
+++ b/include/lxgui/gui_layered_region.hpp
@@ -21,9 +21,9 @@ enum class layer { background, border, artwork, overlay, highlight, special_high
  * must be taken care of by the parent frame.
  */
 class layered_region : public region {
+public:
     using base = region;
 
-public:
     /// Constructor.
     explicit layered_region(
         utils::control_block& block, manager& mgr, const region_core_attributes& attr);
@@ -72,6 +72,8 @@ public:
 
 protected:
     void parse_attributes_(const layout_node& node) override;
+
+    const std::vector<std::string>& get_type_list_() const override;
 
     layer layer_ = layer::artwork;
 };

--- a/include/lxgui/gui_layout_node.hpp
+++ b/include/lxgui/gui_layout_node.hpp
@@ -1,12 +1,12 @@
 #ifndef LXGUI_GUI_LAYOUT_NODE_HPP
 #define LXGUI_GUI_LAYOUT_NODE_HPP
 
+#include "lxgui/gui_out.hpp"
 #include "lxgui/lxgui.hpp"
 #include "lxgui/utils.hpp"
 #include "lxgui/utils_exception.hpp"
 #include "lxgui/utils_string.hpp"
 #include "lxgui/utils_view.hpp"
-#include "lxgui/gui_out.hpp"
 
 #include <string>
 #include <string_view>
@@ -225,7 +225,7 @@ public:
      * \brief Returns the number of children of this node.
      * \return The number of children of this node
      */
-    std::size_t get_children_count() const noexcept {
+    std::size_t get_child_count() const noexcept {
         return child_list_.size();
     }
 

--- a/include/lxgui/gui_region.hpp
+++ b/include/lxgui/gui_region.hpp
@@ -455,7 +455,7 @@ public:
      * \note This region and its children won't be visible until you
      * define at least one anchor.
      */
-    void clear_all_points();
+    void clear_all_anchors();
 
     /**
      * \brief Adjusts this regions anchors to fit the provided region.
@@ -475,17 +475,17 @@ public:
      * \brief Adds/replaces an anchor.
      * \param a The anchor to add
      */
-    void set_point(const anchor_data& a);
+    void set_anchor(const anchor_data& a);
 
     /**
      * \brief Adds/replaces an anchor.
      * \param args Argument to construct a new anchor_data
      */
     template<typename... Args>
-    void set_point(Args&&... args) {
-        constexpr auto set_point_overload =
-            static_cast<void (region::*)(const anchor_data&)>(&region::set_point);
-        (this->*set_point_overload)(anchor_data{std::forward<Args>(args)...});
+    void set_anchor(Args&&... args) {
+        constexpr auto set_anchor_overload =
+            static_cast<void (region::*)(const anchor_data&)>(&region::set_anchor);
+        (this->*set_anchor_overload)(anchor_data{std::forward<Args>(args)...});
     }
 
     /**
@@ -499,7 +499,7 @@ public:
      * \brief Returns the number of defined anchors.
      * \return The number of defined anchors
      */
-    std::size_t get_num_point() const;
+    std::size_t get_anchor_count() const;
 
     /**
      * \brief Returns one of this region's anchor to modify it.
@@ -508,20 +508,20 @@ public:
      * \note After you have modified the anchor, you must call notify_borders_need_update() to
      * ensure that the object's borders are properly updated.
      */
-    anchor& modify_point(point p);
+    anchor& modify_anchor(point p);
 
     /**
      * \brief Returns one of this region's anchor.
      * \param p The anchor point
      * \return A pointer to the anchor, nullptr if none
      */
-    const anchor& get_point(point p) const;
+    const anchor& get_anchor(point p) const;
 
     /**
      * \brief Returns all of this region's anchors.
      * \return All of this region's anchors
      */
-    const std::array<std::optional<anchor>, 9>& get_point_list() const;
+    const std::array<std::optional<anchor>, 9>& get_anchors() const;
 
     /**
      * \brief Round an absolute position on screen to the nearest physical pixel.

--- a/include/lxgui/gui_region.hpp
+++ b/include/lxgui/gui_region.hpp
@@ -388,29 +388,23 @@ public:
      * \brief Returns the type of this region.
      * \return The type of this region
      */
-    const std::string& get_object_type() const;
+    const std::string& get_region_type() const;
 
     /**
      * \brief Checks if this region is of the provided type.
      * \param type_name The type to test
      * \return 'true' if this region is of the provided type
      */
-    bool is_object_type(const std::string& type_name) const;
+    bool is_region_type(const std::string& type_name) const;
 
     /**
      * \brief Checks if this region is of the provided type.
      * \return 'true' if this region is of the provided type
      */
     template<typename ObjectType>
-    bool is_object_type() const {
-        return is_object_type(ObjectType::class_name);
+    bool is_region_type() const {
+        return is_region_type(ObjectType::class_name);
     }
-
-    /**
-     * \brief Returns an array containing all the types of this region.
-     * \return An array containing all the types of this region
-     */
-    const std::vector<std::string>& get_object_type_list() const;
 
     /**
      * \brief Returns the vertical position of this region's bottom border.
@@ -812,9 +806,9 @@ protected:
 template<typename ObjectType>
 const ObjectType* down_cast(const region* self) {
     const ObjectType* object = dynamic_cast<const ObjectType*>(self);
-    if (self && !object && self->is_object_type(ObjectType::class_name)) {
+    if (self && !object && self->is_region_type(ObjectType::class_name)) {
         throw gui::exception(
-            self->get_object_type(), "cannot use down_cast() to " +
+            self->get_region_type(), "cannot use down_cast() to " +
                                          std::string(ObjectType::class_name) +
                                          " as object is being destroyed");
     }
@@ -834,14 +828,14 @@ template<typename ObjectType>
 const ObjectType& down_cast(const region& self) {
     const ObjectType* object = dynamic_cast<const ObjectType*>(self);
     if (self && !object) {
-        if (self.is_object_type(ObjectType::class_name)) {
+        if (self.is_region_type(ObjectType::class_name)) {
             throw gui::exception(
-                self.get_object_type(), "cannot use down_cast() to " +
+                self.get_region_type(), "cannot use down_cast() to " +
                                             std::string(ObjectType::class_name) +
                                             " as object is being destroyed");
         } else {
             throw gui::exception(
-                self.get_object_type(), "cannot use down_cast() to " +
+                self.get_region_type(), "cannot use down_cast() to " +
                                             std::string(ObjectType::class_name) +
                                             " as object is not of the right type");
         }

--- a/include/lxgui/gui_region.hpp
+++ b/include/lxgui/gui_region.hpp
@@ -462,14 +462,14 @@ public:
      * \param obj A pointer to the object you want to wrap
      * \note Removes all anchors and defines two new ones.
      */
-    void set_all_points(const utils::observer_ptr<region>& obj);
+    void set_all_anchors(const utils::observer_ptr<region>& obj);
 
     /**
      * \brief Adjusts this regions anchors to fit the provided region.
      * \param obj_name The name of the object to fit to
      * \note Removes all anchors and defines two new ones.
      */
-    void set_all_points(const std::string& obj_name);
+    void set_all_anchors(const std::string& obj_name);
 
     /**
      * \brief Adds/replaces an anchor.

--- a/include/lxgui/gui_region.hpp
+++ b/include/lxgui/gui_region.hpp
@@ -270,14 +270,14 @@ public:
      * \note Its parent must be shown for it to appear on
      * the screen.
      */
-    virtual void show();
+    void show();
 
     /**
      * \brief hides this region.
      * \note All its children won't be visible on the screen
      * anymore, even if they are still marked as shown.
      */
-    virtual void hide();
+    void hide();
 
     /**
      * \brief shows/hides this region.
@@ -296,7 +296,7 @@ public:
      * \brief Checks if this region can be seen on the screen.
      * \return 'true' if this region can be seen on the screen
      */
-    virtual bool is_visible() const;
+    bool is_visible() const;
 
     /**
      * \brief Changes this region's absolute dimensions (in pixels).

--- a/include/lxgui/gui_region.hpp
+++ b/include/lxgui/gui_region.hpp
@@ -794,8 +794,8 @@ protected:
 
     std::array<std::optional<anchor>, 9>     anchor_list_;
     std::vector<utils::observer_ptr<region>> previous_anchor_parent_list_;
-    bounds2<bool>                            defined_border_list_;
-    bounds2f                                 border_list_;
+    bounds2<bool>                            defined_borders_;
+    bounds2f                                 borders_;
 
     float alpha_      = 1.0f;
     bool  is_shown_   = true;

--- a/include/lxgui/gui_region.hpp
+++ b/include/lxgui/gui_region.hpp
@@ -572,21 +572,20 @@ public:
     bool is_virtual() const;
 
     /**
-     * \brief Flags this object as "special".
-     * \note Special objects are not automatically copied
-     * in the frame inheritance process. They must be
-     * explicitly copied by the derived class
-     * (example: Button will have to copy its button
-     * textures itself).
+     * \brief Flags this region as manually inherited or not.
+     * \note By default, all regions are automatically inherited. This is generally the desired
+     * behavior for regions defined by the user, but it is less desirable for "special" or
+     * "internal" regions necessary for the proper operation of some region types (e.g., the texture
+     * used by a button), which need special treatment or registration.
      */
-    void set_special();
+    void set_manually_inherited(bool manually_inherited);
 
     /**
-     * \brief Checks if this object is special.
-     * \return 'true' if this object is special
-     * \note For more information, see set_special().
+     * \brief Checks if this object is manually inherited.
+     * \return 'true' if this object is manually inherited
+     * \note For more information, see set_manually_inherited().
      */
-    bool is_special() const;
+    bool is_manually_inherited() const;
 
     /**
      * \brief Returns the renderer of this object or its parents.
@@ -787,10 +786,10 @@ protected:
 
     utils::observer_ptr<frame> parent_ = nullptr;
 
-    bool is_special_ = false;
-    bool is_virtual_ = false;
-    bool is_loaded_  = false;
-    bool is_ready_   = true;
+    bool is_manually_inherited_ = false;
+    bool is_virtual_            = false;
+    bool is_loaded_             = false;
+    bool is_ready_              = true;
 
     std::vector<std::string> type_;
 

--- a/include/lxgui/gui_region.hpp
+++ b/include/lxgui/gui_region.hpp
@@ -209,16 +209,9 @@ public:
     const std::string& get_name() const;
 
     /**
-     * \brief Returns this region's Lua name.
-     * \return This region's Lua name
-     */
-    const std::string& get_lua_name() const;
-
-    /**
      * \brief Returns this region's raw name.
      * \return This region's raw name
-     * \note This is the name of the region before "$parent"
-     * has been replaced by its parent's name.
+     * \note This is the name of the region before "$parent" has been replaced by its parent's name.
      */
     const std::string& get_raw_name() const;
 
@@ -781,7 +774,6 @@ protected:
 
     std::string name_;
     std::string raw_name_;
-    std::string lua_name_;
 
     utils::observer_ptr<frame> parent_ = nullptr;
 

--- a/include/lxgui/gui_region.hpp
+++ b/include/lxgui/gui_region.hpp
@@ -733,7 +733,8 @@ protected:
     virtual void update_borders_();
     virtual void update_anchors_();
 
-    sol::state& get_lua_();
+    sol::state&       get_lua_();
+    const sol::state& get_lua_() const;
 
     template<typename T>
     void create_glue_(T& self);
@@ -801,8 +802,6 @@ protected:
     vector2f dimensions_;
 
     std::vector<utils::observer_ptr<region>> anchored_object_list_;
-
-    std::unordered_map<std::string, sol::object> lua_members_;
 };
 
 /**

--- a/include/lxgui/gui_region.hpp
+++ b/include/lxgui/gui_region.hpp
@@ -782,7 +782,6 @@ protected:
     std::string name_;
     std::string raw_name_;
     std::string lua_name_;
-    std::size_t id_ = std::numeric_limits<std::size_t>::max();
 
     utils::observer_ptr<frame> parent_ = nullptr;
 

--- a/include/lxgui/gui_region.hpp
+++ b/include/lxgui/gui_region.hpp
@@ -407,6 +407,14 @@ public:
     }
 
     /**
+     * \brief Checks if this region is of a type equal or derived from the supplied region.
+     * \return 'true' if this region is of a type equal or derived from the supplied region
+     */
+    bool is_region_type(const region& obj) const {
+        return is_region_type(obj.get_region_type());
+    }
+
+    /**
      * \brief Returns the vertical position of this region's bottom border.
      * \return The vertical position of this region's bottom border
      */
@@ -730,6 +738,11 @@ protected:
     template<typename T>
     void create_glue_(T& self);
 
+    template<typename T>
+    static const std::vector<std::string>& get_type_list_impl_();
+
+    virtual const std::vector<std::string>& get_type_list_() const;
+
     void        set_lua_member_(std::string key, sol::stack_object value);
     sol::object get_lua_member_(const std::string& key) const;
 
@@ -775,8 +788,6 @@ protected:
     bool is_virtual_            = false;
     bool is_loaded_             = false;
     bool is_ready_              = true;
-
-    std::vector<std::string> type_;
 
     std::array<std::optional<anchor>, 9>     anchor_list_;
     std::vector<utils::observer_ptr<region>> previous_anchor_parent_list_;
@@ -909,7 +920,7 @@ utils::observer_ptr<ObjectType> down_cast(utils::observer_ptr<region>&& object) 
  * \param self The raw pointer to get an observer from
  * \return The observer pointer.
  * \note This returns the same things as self->observer_from_this(),
- * but returning a pointer to the most-derived type known form the
+ * but returning a pointer to the most-derived type known from the
  * input pointer.
  */
 template<typename ObjectType>

--- a/include/lxgui/gui_region.hpp
+++ b/include/lxgui/gui_region.hpp
@@ -731,7 +731,6 @@ protected:
     bool make_borders_(float& min, float& max, float center, float size) const;
 
     virtual void update_borders_();
-    virtual void update_anchors_();
 
     sol::state&       get_lua_();
     const sol::state& get_lua_() const;
@@ -790,10 +789,9 @@ protected:
     bool is_loaded_             = false;
     bool is_ready_              = true;
 
-    std::array<std::optional<anchor>, 9>     anchor_list_;
-    std::vector<utils::observer_ptr<region>> previous_anchor_parent_list_;
-    bounds2<bool>                            defined_borders_;
-    bounds2f                                 borders_;
+    std::array<std::optional<anchor>, 9> anchor_list_;
+    bounds2<bool>                        defined_borders_;
+    bounds2f                             borders_;
 
     float alpha_      = 1.0f;
     bool  is_shown_   = true;

--- a/include/lxgui/gui_region_tpl.hpp
+++ b/include/lxgui/gui_region_tpl.hpp
@@ -139,10 +139,26 @@ void region::create_glue_(T& self) {
 
 template<typename T>
 void region::initialize_(T& self, const region_core_attributes& /*attr*/) {
-    type_.push_back(T::class_name);
-
     if (!is_virtual())
         create_glue_(self);
+}
+
+template<typename T>
+const std::vector<std::string>& region::get_type_list_impl_() {
+    if constexpr (std::is_same_v<T, region>) {
+        static const std::vector<std::string> type = {region::class_name};
+
+        return type;
+    } else {
+        static const std::vector<std::string> type = []() {
+            using base = typename T::base;
+            auto list  = get_type_list_impl_<base>();
+            list.push_back(T::class_name);
+            return list;
+        }();
+
+        return type;
+    }
 }
 
 } // namespace lxgui::gui

--- a/include/lxgui/gui_region_tpl.hpp
+++ b/include/lxgui/gui_region_tpl.hpp
@@ -134,7 +134,7 @@ constexpr auto member_function() {
 
 template<typename T>
 void region::create_glue_(T& self) {
-    get_lua_().globals()[lua_name_] = observer_from(&self);
+    get_lua_().globals()[get_name()] = observer_from(&self);
 }
 
 template<typename T>

--- a/include/lxgui/gui_renderer.hpp
+++ b/include/lxgui/gui_renderer.hpp
@@ -155,8 +155,14 @@ public:
     void auto_detect_settings();
 
     /**
-     * \brief Returns the number of batches of vertices sent to the GPU during the last frame.
-     * \return The number of batches of vertices sent to the GPU during the last frame
+     * \brief Resets the number of batches to zero (for analytics only).
+     * \note See get_batch_count(). This should be called a the beginning of a frame.
+     */
+    void reset_batch_count();
+
+    /**
+     * \brief Returns the number of batches of vertices sent to the GPU since the last call to reset_batch_count.
+     * \return The number of batches of vertices sent to the GPU since the last call to reset_batch_count
      * \note This will be zero unless is_quad_batching_enabled() is 'true'.
      */
     std::size_t get_batch_count() const;

--- a/include/lxgui/gui_renderer.hpp
+++ b/include/lxgui/gui_renderer.hpp
@@ -156,16 +156,23 @@ public:
 
     /**
      * \brief Resets the number of batches to zero (for analytics only).
-     * \note See get_batch_count(). This should be called a the beginning of a frame.
+     * \note See get_batch_count() and get_vertex_count().
+     * This should be called a the beginning of a frame.
      */
-    void reset_batch_count();
+    void reset_counters();
 
     /**
-     * \brief Returns the number of batches of vertices sent to the GPU since the last call to reset_batch_count.
-     * \return The number of batches of vertices sent to the GPU since the last call to reset_batch_count
+     * \brief Returns the number of batches of vertices sent to the GPU since the last call to reset_counters.
+     * \return The number of batches of vertices sent to the GPU since the last call to reset_counters
      * \note This will be zero unless is_quad_batching_enabled() is 'true'.
      */
     std::size_t get_batch_count() const;
+
+    /**
+     * \brief Returns the number of vertices sent to the GPU since the last call to reset_counters.
+     * \return The number of vertices sent to the GPU since the last call to reset_counters
+     */
+    std::size_t get_vertex_count() const;
 
     /**
      * \brief Begins rendering on a particular render target.
@@ -507,10 +514,12 @@ private:
     static constexpr std::size_t                        batching_cache_cycle_size = 16u;
     std::array<quad_batcher, batching_cache_cycle_size> quad_cache_;
 
-    const gui::material* current_material_       = nullptr;
-    std::size_t          current_quad_cache_     = 0u;
-    std::size_t          batch_count_            = 0u;
-    std::size_t          last_frame_batch_count_ = 0u;
+    const gui::material* current_material_        = nullptr;
+    std::size_t          current_quad_cache_      = 0u;
+    std::size_t          batch_count_             = 0u;
+    std::size_t          vertex_count_            = 0u;
+    std::size_t          last_frame_batch_count_  = 0u;
+    std::size_t          last_frame_vertex_count_ = 0u;
 };
 
 } // namespace lxgui::gui

--- a/include/lxgui/gui_renderer.hpp
+++ b/include/lxgui/gui_renderer.hpp
@@ -129,7 +129,7 @@ public:
      * \brief Count the total number of texture atlas pages currently in use.
      * \return The total number of texture atlas pages currently in use
      */
-    std::size_t get_num_texture_atlas_pages() const;
+    std::size_t get_texture_atlas_page_count() const;
 
     /**
      * \brief Checks if the renderer supports vertex caches.

--- a/include/lxgui/gui_scroll_frame.hpp
+++ b/include/lxgui/gui_scroll_frame.hpp
@@ -33,9 +33,9 @@ class texture;
  * - `OnVerticalScroll`: Triggered by scroll_frame::set_vertical_scroll.
  */
 class scroll_frame : public frame, public frame_renderer {
+public:
     using base = frame;
 
-public:
     /// Constructor.
     explicit scroll_frame(
         utils::control_block& block, manager& mgr, const frame_core_attributes& attr);
@@ -175,6 +175,8 @@ public:
 protected:
     void         parse_all_nodes_before_children_(const layout_node& node) override;
     virtual void parse_scroll_child_node_(const layout_node& node);
+
+    const std::vector<std::string>& get_type_list_() const override;
 
     void update_scroll_range_();
     void rebuild_scroll_render_target_();

--- a/include/lxgui/gui_slider.hpp
+++ b/include/lxgui/gui_slider.hpp
@@ -28,9 +28,9 @@ class texture;
  * previous value would not satisfy the new constraints.
  */
 class slider : public frame {
+public:
     using base = frame;
 
-public:
     /// Constructor.
     explicit slider(utils::control_block& block, manager& mgr, const frame_core_attributes& attr);
 
@@ -204,6 +204,8 @@ protected:
 
     void parse_attributes_(const layout_node& node) override;
     void parse_all_nodes_before_children_(const layout_node& node) override;
+
+    const std::vector<std::string>& get_type_list_() const override;
 
     orientation orientation_ = orientation::vertical;
 

--- a/include/lxgui/gui_status_bar.hpp
+++ b/include/lxgui/gui_status_bar.hpp
@@ -30,9 +30,9 @@ class texture;
  * the previous value would not satisfy the new constraints.
  */
 class status_bar : public frame {
+public:
     using base = frame;
 
-public:
     /// Constructor.
     explicit status_bar(
         utils::control_block& block, manager& mgr, const frame_core_attributes& attr);
@@ -185,6 +185,8 @@ protected:
 
     void parse_attributes_(const layout_node& node) override;
     void parse_all_nodes_before_children_(const layout_node& node) override;
+
+    const std::vector<std::string>& get_type_list_() const override;
 
     orientation orientation_ = orientation::horizontal;
     bool        is_reversed_ = false;

--- a/include/lxgui/gui_text.hpp
+++ b/include/lxgui/gui_text.hpp
@@ -167,7 +167,7 @@ public:
      * \brief Returns the number of text lines.
      * \return The number of text lines
      */
-    std::size_t get_num_lines() const;
+    std::size_t get_line_count() const;
 
     /**
      * \brief Returns the length of a provided string.
@@ -317,11 +317,11 @@ public:
      * \return The number of letters currently displayed
      * \note This function may update the quad cache as needed.
      */
-    std::size_t get_num_letters() const;
+    std::size_t get_letter_count() const;
 
     /**
      * \brief Returns the quad for the letter at the provided index (position, texture coords, color).
-     * \param index The index of the letter (0: first letter); must be less than get_num_letters().
+     * \param index The index of the letter (0: first letter); must be less than get_letter_count().
      * \return The quad of the specified letter
      * \note The vertex positions in the quad do not account for the rendering position
      * provided to render(). The first letter always has its top-left corner as

--- a/include/lxgui/gui_text.hpp
+++ b/include/lxgui/gui_text.hpp
@@ -35,7 +35,9 @@ public:
      * \param outline_fnt The font to use for outlines
      */
     explicit text(
-        renderer& rdr, std::shared_ptr<font> fnt, std::shared_ptr<font> outline_fnt = nullptr);
+        renderer&                   rdr,
+        std::shared_ptr<const font> fnt,
+        std::shared_ptr<const font> outline_fnt = nullptr);
 
     // Non-copiable, non-movable
     text(const text&) = delete;
@@ -358,7 +360,7 @@ private:
     float round_to_pixel_(
         float value, utils::rounding_method method = utils::rounding_method::nearest) const;
 
-    std::array<vertex, 4> create_letter_quad_(gui::font& font, char32_t c) const;
+    std::array<vertex, 4> create_letter_quad_(const gui::font& font, char32_t c) const;
     std::array<vertex, 4> create_letter_quad_(char32_t c) const;
     std::array<vertex, 4> create_outline_letter_quad_(char32_t c) const;
 
@@ -380,9 +382,9 @@ private:
     alignment_x align_x_                = alignment_x::left;
     alignment_y align_y_                = alignment_y::middle;
 
-    std::shared_ptr<font> font_;
-    std::shared_ptr<font> outline_font_;
-    utils::ustring        unicode_text_;
+    std::shared_ptr<const font> font_;
+    std::shared_ptr<const font> outline_font_;
+    utils::ustring              unicode_text_;
 
     mutable bool        update_cache_flag_ = false;
     mutable float       width_             = 0.0f;

--- a/include/lxgui/gui_texture.hpp
+++ b/include/lxgui/gui_texture.hpp
@@ -21,9 +21,9 @@ class render_target;
  * or a plain color (possibly with a different color on each corner).
  */
 class texture : public layered_region {
+public:
     using base = layered_region;
 
-public:
     enum class blend_mode { none, blend, key, add, mod };
 
     /// Constructor.
@@ -238,6 +238,8 @@ private:
     void parse_attributes_(const layout_node& node) override;
     void parse_tex_coords_node_(const layout_node& node);
     void parse_gradient_node_(const layout_node& node);
+
+    const std::vector<std::string>& get_type_list_() const override;
 
     void update_dimensions_from_tex_coord_();
     void update_borders_() override;

--- a/include/lxgui/gui_vertex_cache.hpp
+++ b/include/lxgui/gui_vertex_cache.hpp
@@ -70,7 +70,7 @@ public:
      * \brief Returns the number of vertices stored in this cache.
      * \return The number of vertices stored in this cache
      */
-    std::size_t get_num_vertex() const {
+    std::size_t get_vertex_count() const {
         return num_vertex_;
     }
 

--- a/include/lxgui/gui_vertex_cache.hpp
+++ b/include/lxgui/gui_vertex_cache.hpp
@@ -66,8 +66,17 @@ public:
      */
     virtual void update(const vertex* vertex_data, std::size_t num_vertex) = 0;
 
+    /**
+     * \brief Returns the number of vertices stored in this cache.
+     * \return The number of vertices stored in this cache
+     */
+    std::size_t get_num_vertex() const {
+        return num_vertex_;
+    }
+
 protected:
-    type type_ = type::triangles;
+    type        type_       = type::triangles;
+    std::size_t num_vertex_ = 0;
 };
 
 } // namespace lxgui::gui

--- a/include/lxgui/impl/gui_sfml_vertex_cache.hpp
+++ b/include/lxgui/impl/gui_sfml_vertex_cache.hpp
@@ -58,7 +58,6 @@ public:
     const sf::VertexBuffer& get_impl() const;
 
 private:
-    std::size_t      num_vertex_ = 0u;
     sf::VertexBuffer buffer_;
 };
 

--- a/include/lxgui/impl/gui_sfml_vertex_cache.hpp
+++ b/include/lxgui/impl/gui_sfml_vertex_cache.hpp
@@ -49,7 +49,7 @@ public:
      * \brief Returns the number of vertices currently stored in the cache.
      * \return The number of vertices currently stored in the cache
      */
-    std::size_t get_num_vertex() const;
+    std::size_t get_vertex_count() const;
 
     /**
      * \brief Returns the SFML vertex buffer object.

--- a/src/gui_anchor.cpp
+++ b/src/gui_anchor.cpp
@@ -33,7 +33,7 @@ void anchor::update_parent_(region& object) {
     if (obj_parent) {
         utils::replace(parent_full_name, "$parent", obj_parent->get_name());
     } else if (parent_full_name.find("$parent") != parent_full_name.npos) {
-        gui::out << gui::error << "gui::" << object.get_object_type() << ": "
+        gui::out << gui::error << "gui::" << object.get_region_type() << ": "
                  << "region \"" << object.get_name() << "\" tries to anchor to \""
                  << parent_full_name << "\", but '$parent' does not exist." << std::endl;
         return;
@@ -43,7 +43,7 @@ void anchor::update_parent_(region& object) {
         object.get_registry().get_region_by_name(parent_full_name);
 
     if (!new_parent) {
-        gui::out << gui::error << "gui::" << object.get_object_type() << ": "
+        gui::out << gui::error << "gui::" << object.get_region_type() << ": "
                  << "region \"" << object.get_name() << "\" tries to anchor to \""
                  << parent_full_name << "\" but this region does not (yet?) exist." << std::endl;
         return;

--- a/src/gui_anchor.cpp
+++ b/src/gui_anchor.cpp
@@ -31,7 +31,7 @@ void anchor::update_parent_(region& object) {
 
     std::string parent_full_name = parent_name;
     if (obj_parent) {
-        utils::replace(parent_full_name, "$parent", obj_parent->get_lua_name());
+        utils::replace(parent_full_name, "$parent", obj_parent->get_name());
     } else if (parent_full_name.find("$parent") != parent_full_name.npos) {
         gui::out << gui::error << "gui::" << object.get_object_type() << ": "
                  << "region \"" << object.get_name() << "\" tries to anchor to \""

--- a/src/gui_animated_texture.cpp
+++ b/src/gui_animated_texture.cpp
@@ -102,7 +102,7 @@ const std::string& animated_texture::get_texture_file() const {
 
 color animated_texture::get_vertex_color(std::size_t index) const {
     if (index >= 4) {
-        gui::out << gui::error << "gui::" << type_.back() << ": "
+        gui::out << gui::error << "gui::" << get_region_type() << ": "
                  << "Vertex index out of bound (" << index << ")." << std::endl;
         return color::white;
     }
@@ -152,7 +152,7 @@ void animated_texture::set_texture(const std::string& file_name) {
         if (!is_apparent_height_defined())
             set_height(quad_.mat->get_rect().height());
     } else {
-        gui::out << gui::error << "gui::" << type_.back() << ": "
+        gui::out << gui::error << "gui::" << get_region_type() << ": "
                  << "Cannot load file \"" << file_ << "\" for \"" << name_
                  << "\". Using white animated_texture instead." << std::endl;
     }
@@ -171,7 +171,7 @@ void animated_texture::set_vertex_color(const color& c, std::size_t index) {
     }
 
     if (index >= 4) {
-        gui::out << gui::error << "gui::" << type_.back() << ": "
+        gui::out << gui::error << "gui::" << get_region_type() << ": "
                  << "Vertex index out of bound (" << index << ")." << std::endl;
         return;
     }

--- a/src/gui_animated_texture.cpp
+++ b/src/gui_animated_texture.cpp
@@ -208,4 +208,8 @@ void animated_texture::update_borders_() {
     quad_.v[3].pos = borders_.bottom_left();
 }
 
+const std::vector<std::string>& animated_texture::get_type_list_() const {
+    return get_type_list_impl_<animated_texture>();
+}
+
 } // namespace lxgui::gui

--- a/src/gui_animated_texture.cpp
+++ b/src/gui_animated_texture.cpp
@@ -202,10 +202,10 @@ void animated_texture::update_tex_coords_() {
 void animated_texture::update_borders_() {
     base::update_borders_();
 
-    quad_.v[0].pos = border_list_.top_left();
-    quad_.v[1].pos = border_list_.top_right();
-    quad_.v[2].pos = border_list_.bottom_right();
-    quad_.v[3].pos = border_list_.bottom_left();
+    quad_.v[0].pos = borders_.top_left();
+    quad_.v[1].pos = borders_.top_right();
+    quad_.v[2].pos = borders_.bottom_right();
+    quad_.v[3].pos = borders_.bottom_left();
 }
 
 } // namespace lxgui::gui

--- a/src/gui_atlas.cpp
+++ b/src/gui_atlas.cpp
@@ -227,7 +227,7 @@ bool atlas::add_font(const std::string& font_name, std::shared_ptr<gui::font> fn
     }
 }
 
-std::size_t atlas::get_num_pages() const {
+std::size_t atlas::get_page_count() const {
     return page_list_.size();
 }
 

--- a/src/gui_button.cpp
+++ b/src/gui_button.cpp
@@ -436,4 +436,8 @@ const vector2f& button::get_pushed_text_offset() const {
     return pushed_text_offset_;
 }
 
+const std::vector<std::string>& button::get_type_list_() const {
+    return get_type_list_impl_<button>();
+}
+
 } // namespace lxgui::gui

--- a/src/gui_button.cpp
+++ b/src/gui_button.cpp
@@ -74,7 +74,7 @@ void button::copy_from(const region& obj) {
             this->create_layered_region<texture>(other_texture->get_draw_layer(), std::move(attr));
 
         if (tex) {
-            tex->set_special();
+            tex->set_manually_inherited(true);
             tex->notify_loaded();
             this->set_normal_texture(tex);
         }
@@ -89,7 +89,7 @@ void button::copy_from(const region& obj) {
             this->create_layered_region<texture>(other_texture->get_draw_layer(), std::move(attr));
 
         if (tex) {
-            tex->set_special();
+            tex->set_manually_inherited(true);
             tex->notify_loaded();
             this->set_pushed_texture(tex);
         }
@@ -104,7 +104,7 @@ void button::copy_from(const region& obj) {
             this->create_layered_region<texture>(other_texture->get_draw_layer(), std::move(attr));
 
         if (tex) {
-            tex->set_special();
+            tex->set_manually_inherited(true);
             tex->notify_loaded();
             this->set_highlight_texture(tex);
         }
@@ -119,7 +119,7 @@ void button::copy_from(const region& obj) {
             this->create_layered_region<texture>(other_texture->get_draw_layer(), std::move(attr));
 
         if (tex) {
-            tex->set_special();
+            tex->set_manually_inherited(true);
             tex->notify_loaded();
             this->set_disabled_texture(tex);
         }
@@ -134,7 +134,7 @@ void button::copy_from(const region& obj) {
             this->create_layered_region<font_string>(other_text->get_draw_layer(), std::move(attr));
 
         if (fstr) {
-            fstr->set_special();
+            fstr->set_manually_inherited(true);
             fstr->notify_loaded();
             this->set_normal_text(fstr);
         }
@@ -149,7 +149,7 @@ void button::copy_from(const region& obj) {
             this->create_layered_region<font_string>(other_text->get_draw_layer(), std::move(attr));
 
         if (fstr) {
-            fstr->set_special();
+            fstr->set_manually_inherited(true);
             fstr->notify_loaded();
             this->set_highlight_text(fstr);
         }
@@ -164,7 +164,7 @@ void button::copy_from(const region& obj) {
             this->create_layered_region<font_string>(other_text->get_draw_layer(), std::move(attr));
 
         if (fstr) {
-            fstr->set_special();
+            fstr->set_manually_inherited(true);
             fstr->notify_loaded();
             this->set_disabled_text(fstr);
         }

--- a/src/gui_button.cpp
+++ b/src/gui_button.cpp
@@ -67,7 +67,7 @@ void button::copy_from(const region& obj) {
 
     if (const texture* other_texture = button_obj->get_normal_texture().get()) {
         region_core_attributes attr;
-        attr.name        = other_texture->get_name();
+        attr.name        = other_texture->get_raw_name();
         attr.inheritance = {button_obj->get_normal_texture()};
 
         auto tex =
@@ -82,7 +82,7 @@ void button::copy_from(const region& obj) {
 
     if (const texture* other_texture = button_obj->get_pushed_texture().get()) {
         region_core_attributes attr;
-        attr.name        = other_texture->get_name();
+        attr.name        = other_texture->get_raw_name();
         attr.inheritance = {button_obj->get_pushed_texture()};
 
         auto tex =
@@ -97,7 +97,7 @@ void button::copy_from(const region& obj) {
 
     if (const texture* other_texture = button_obj->get_highlight_texture().get()) {
         region_core_attributes attr;
-        attr.name        = other_texture->get_name();
+        attr.name        = other_texture->get_raw_name();
         attr.inheritance = {button_obj->get_highlight_texture()};
 
         auto tex =
@@ -112,7 +112,7 @@ void button::copy_from(const region& obj) {
 
     if (const texture* other_texture = button_obj->get_disabled_texture().get()) {
         region_core_attributes attr;
-        attr.name        = other_texture->get_name();
+        attr.name        = other_texture->get_raw_name();
         attr.inheritance = {button_obj->get_disabled_texture()};
 
         auto tex =
@@ -127,7 +127,7 @@ void button::copy_from(const region& obj) {
 
     if (const font_string* other_text = button_obj->get_normal_text().get()) {
         region_core_attributes attr;
-        attr.name        = other_text->get_name();
+        attr.name        = other_text->get_raw_name();
         attr.inheritance = {button_obj->get_normal_text()};
 
         auto fstr =
@@ -142,7 +142,7 @@ void button::copy_from(const region& obj) {
 
     if (const font_string* other_text = button_obj->get_highlight_text().get()) {
         region_core_attributes attr;
-        attr.name        = other_text->get_name();
+        attr.name        = other_text->get_raw_name();
         attr.inheritance = {button_obj->get_highlight_text()};
 
         auto fstr =
@@ -157,7 +157,7 @@ void button::copy_from(const region& obj) {
 
     if (const font_string* other_text = button_obj->get_disabled_text().get()) {
         region_core_attributes attr;
-        attr.name        = other_text->get_name();
+        attr.name        = other_text->get_raw_name();
         attr.inheritance = {button_obj->get_disabled_text()};
 
         auto fstr =

--- a/src/gui_button_parser.cpp
+++ b/src/gui_button_parser.cpp
@@ -29,7 +29,7 @@ void button::parse_all_nodes_before_children_(const layout_node& node) {
 
         auto tex = parse_region_(defaulted, layer, "Texture");
         if (tex) {
-            tex->set_special();
+            tex->set_manually_inherited(true);
             set_normal_texture(utils::static_pointer_cast<texture>(tex));
         }
 
@@ -46,7 +46,7 @@ void button::parse_all_nodes_before_children_(const layout_node& node) {
 
         auto tex = parse_region_(defaulted, layer, "Texture");
         if (tex) {
-            tex->set_special();
+            tex->set_manually_inherited(true);
             set_pushed_texture(utils::static_pointer_cast<texture>(tex));
         }
 
@@ -63,7 +63,7 @@ void button::parse_all_nodes_before_children_(const layout_node& node) {
 
         auto tex = parse_region_(defaulted, layer, "Texture");
         if (tex) {
-            tex->set_special();
+            tex->set_manually_inherited(true);
             set_disabled_texture(utils::static_pointer_cast<texture>(tex));
         }
 
@@ -80,7 +80,7 @@ void button::parse_all_nodes_before_children_(const layout_node& node) {
 
         auto tex = parse_region_(defaulted, layer, "Texture");
         if (tex) {
-            tex->set_special();
+            tex->set_manually_inherited(true);
             set_highlight_texture(utils::static_pointer_cast<texture>(tex));
         }
 
@@ -97,7 +97,7 @@ void button::parse_all_nodes_before_children_(const layout_node& node) {
 
         auto fstr = parse_region_(defaulted, layer, "FontString");
         if (fstr) {
-            fstr->set_special();
+            fstr->set_manually_inherited(true);
             set_normal_text(utils::static_pointer_cast<font_string>(fstr));
         }
 
@@ -114,7 +114,7 @@ void button::parse_all_nodes_before_children_(const layout_node& node) {
 
         auto fstr = parse_region_(defaulted, layer, "FontString");
         if (fstr) {
-            fstr->set_special();
+            fstr->set_manually_inherited(true);
             set_highlight_text(utils::static_pointer_cast<font_string>(fstr));
         }
 
@@ -131,7 +131,7 @@ void button::parse_all_nodes_before_children_(const layout_node& node) {
 
         auto fstr = parse_region_(defaulted, layer, "FontString");
         if (fstr) {
-            fstr->set_special();
+            fstr->set_manually_inherited(true);
             set_disabled_text(utils::static_pointer_cast<font_string>(fstr));
         }
 

--- a/src/gui_button_parser.cpp
+++ b/src/gui_button_parser.cpp
@@ -25,7 +25,7 @@ void button::parse_all_nodes_before_children_(const layout_node& node) {
 
         layout_node defaulted = *special_node;
         defaulted.get_or_set_attribute_value("name", "$parentNormalTexture");
-        defaulted.get_or_set_attribute_value("setAllPoints", "true");
+        defaulted.get_or_set_attribute_value("setAllAnchors", "true");
 
         auto tex = parse_region_(defaulted, layer, "Texture");
         if (tex) {
@@ -42,7 +42,7 @@ void button::parse_all_nodes_before_children_(const layout_node& node) {
 
         layout_node defaulted = *special_node;
         defaulted.get_or_set_attribute_value("name", "$parentPushedTexture");
-        defaulted.get_or_set_attribute_value("setAllPoints", "true");
+        defaulted.get_or_set_attribute_value("setAllAnchors", "true");
 
         auto tex = parse_region_(defaulted, layer, "Texture");
         if (tex) {
@@ -59,7 +59,7 @@ void button::parse_all_nodes_before_children_(const layout_node& node) {
 
         layout_node defaulted = *special_node;
         defaulted.get_or_set_attribute_value("name", "$parentDisabledTexture");
-        defaulted.get_or_set_attribute_value("setAllPoints", "true");
+        defaulted.get_or_set_attribute_value("setAllAnchors", "true");
 
         auto tex = parse_region_(defaulted, layer, "Texture");
         if (tex) {
@@ -76,7 +76,7 @@ void button::parse_all_nodes_before_children_(const layout_node& node) {
 
         layout_node defaulted = *special_node;
         defaulted.get_or_set_attribute_value("name", "$parentHighlightTexture");
-        defaulted.get_or_set_attribute_value("setAllPoints", "true");
+        defaulted.get_or_set_attribute_value("setAllAnchors", "true");
 
         auto tex = parse_region_(defaulted, layer, "Texture");
         if (tex) {
@@ -93,7 +93,7 @@ void button::parse_all_nodes_before_children_(const layout_node& node) {
 
         layout_node defaulted = *special_node;
         defaulted.get_or_set_attribute_value("name", "$parentNormalText");
-        defaulted.get_or_set_attribute_value("setAllPoints", "true");
+        defaulted.get_or_set_attribute_value("setAllAnchors", "true");
 
         auto fstr = parse_region_(defaulted, layer, "FontString");
         if (fstr) {
@@ -110,7 +110,7 @@ void button::parse_all_nodes_before_children_(const layout_node& node) {
 
         layout_node defaulted = *special_node;
         defaulted.get_or_set_attribute_value("name", "$parentHighlightText");
-        defaulted.get_or_set_attribute_value("setAllPoints", "true");
+        defaulted.get_or_set_attribute_value("setAllAnchors", "true");
 
         auto fstr = parse_region_(defaulted, layer, "FontString");
         if (fstr) {
@@ -127,7 +127,7 @@ void button::parse_all_nodes_before_children_(const layout_node& node) {
 
         layout_node defaulted = *special_node;
         defaulted.get_or_set_attribute_value("name", "$parentDisabledText");
-        defaulted.get_or_set_attribute_value("setAllPoints", "true");
+        defaulted.get_or_set_attribute_value("setAllAnchors", "true");
 
         auto fstr = parse_region_(defaulted, layer, "FontString");
         if (fstr) {

--- a/src/gui_check_button.cpp
+++ b/src/gui_check_button.cpp
@@ -28,7 +28,7 @@ void check_button::copy_from(const region& obj) {
 
     if (const texture* checked_texture = button_obj->get_checked_texture().get()) {
         region_core_attributes attr;
-        attr.name        = checked_texture->get_name();
+        attr.name        = checked_texture->get_raw_name();
         attr.inheritance = {button_obj->get_checked_texture()};
 
         auto tex = this->create_layered_region<texture>(
@@ -43,7 +43,7 @@ void check_button::copy_from(const region& obj) {
 
     if (const texture* disabled_texture = button_obj->get_disabled_checked_texture().get()) {
         region_core_attributes attr;
-        attr.name        = disabled_texture->get_name();
+        attr.name        = disabled_texture->get_raw_name();
         attr.inheritance = {button_obj->get_disabled_checked_texture()};
 
         auto tex = this->create_layered_region<texture>(

--- a/src/gui_check_button.cpp
+++ b/src/gui_check_button.cpp
@@ -144,4 +144,8 @@ void check_button::set_disabled_checked_texture(utils::observer_ptr<texture> tex
     disabled_checked_texture_->set_shown(is_checked() && state_ == state::disabled);
 }
 
+const std::vector<std::string>& check_button::get_type_list_() const {
+    return get_type_list_impl_<check_button>();
+}
+
 } // namespace lxgui::gui

--- a/src/gui_check_button.cpp
+++ b/src/gui_check_button.cpp
@@ -35,7 +35,7 @@ void check_button::copy_from(const region& obj) {
             checked_texture->get_draw_layer(), std::move(attr));
 
         if (tex) {
-            tex->set_special();
+            tex->set_manually_inherited(true);
             tex->notify_loaded();
             this->set_checked_texture(tex);
         }
@@ -50,7 +50,7 @@ void check_button::copy_from(const region& obj) {
             disabled_texture->get_draw_layer(), std::move(attr));
 
         if (tex) {
-            tex->set_special();
+            tex->set_manually_inherited(true);
             tex->notify_loaded();
             this->set_disabled_checked_texture(tex);
         }

--- a/src/gui_check_button_parser.cpp
+++ b/src/gui_check_button_parser.cpp
@@ -13,7 +13,7 @@ void check_button::parse_all_nodes_before_children_(const layout_node& node) {
 
         layout_node defaulted = *special_node;
         defaulted.get_or_set_attribute_value("name", "$parentCheckedTexture");
-        defaulted.get_or_set_attribute_value("setAllPoints", "true");
+        defaulted.get_or_set_attribute_value("setAllAnchors", "true");
 
         auto tex = parse_region_(defaulted, layer, "Texture");
         if (tex) {
@@ -30,7 +30,7 @@ void check_button::parse_all_nodes_before_children_(const layout_node& node) {
 
         layout_node defaulted = *special_node;
         defaulted.get_or_set_attribute_value("name", "$parentDisabledCheckedTexture");
-        defaulted.get_or_set_attribute_value("setAllPoints", "true");
+        defaulted.get_or_set_attribute_value("setAllAnchors", "true");
 
         auto tex = parse_region_(defaulted, layer, "Texture");
         if (tex) {

--- a/src/gui_check_button_parser.cpp
+++ b/src/gui_check_button_parser.cpp
@@ -17,7 +17,7 @@ void check_button::parse_all_nodes_before_children_(const layout_node& node) {
 
         auto tex = parse_region_(defaulted, layer, "Texture");
         if (tex) {
-            tex->set_special();
+            tex->set_manually_inherited(true);
             set_checked_texture(utils::static_pointer_cast<texture>(tex));
         }
 
@@ -34,7 +34,7 @@ void check_button::parse_all_nodes_before_children_(const layout_node& node) {
 
         auto tex = parse_region_(defaulted, layer, "Texture");
         if (tex) {
-            tex->set_special();
+            tex->set_manually_inherited(true);
             set_disabled_checked_texture(utils::static_pointer_cast<texture>(tex));
         }
 

--- a/src/gui_edit_box.cpp
+++ b/src/gui_edit_box.cpp
@@ -891,13 +891,13 @@ std::size_t edit_box::get_letter_id_at_(const vector2f& position) const {
 
     const text* text = font_string_->get_text_object();
 
-    float local_x = position.x - border_list_.left - text_insets_.left;
-    // float local_y = position.y - border_list_.top  - text_insets_.top;
+    float local_x = position.x - borders_.left - text_insets_.left;
+    // float local_y = position.y - borders_.top  - text_insets_.top;
 
     if (!is_multi_line_) {
-        if (position.x < border_list_.left + text_insets_.left)
+        if (position.x < borders_.left + text_insets_.left)
             return display_pos_;
-        else if (position.x > border_list_.right - text_insets_.right)
+        else if (position.x > borders_.right - text_insets_.right)
             return displayed_text_.size() + display_pos_;
 
         std::size_t num_letters =

--- a/src/gui_edit_box.cpp
+++ b/src/gui_edit_box.cpp
@@ -64,7 +64,7 @@ void edit_box::copy_from(const region& obj) {
         auto fnt = this->create_layered_region<font_string>(fs->get_draw_layer(), std::move(attr));
 
         if (fnt) {
-            fnt->set_special();
+            fnt->set_manually_inherited(true);
             fnt->notify_loaded();
             this->set_font_string(fnt);
         }
@@ -598,7 +598,7 @@ void edit_box::create_font_string_() {
     if (!fnt)
         return;
 
-    fnt->set_special();
+    fnt->set_manually_inherited(true);
     fnt->notify_loaded();
     set_font_string(fnt);
 }
@@ -611,7 +611,7 @@ void edit_box::create_highlight_() {
     if (!highlight)
         return;
 
-    highlight->set_special();
+    highlight->set_manually_inherited(true);
 
     highlight->set_point(point::top, vector2f(0.0f, text_insets_.top));
     highlight->set_point(point::bottom, vector2f(0.0f, -text_insets_.bottom));
@@ -631,7 +631,7 @@ void edit_box::create_carret_() {
         if (!carret)
             return;
 
-        carret->set_special();
+        carret->set_manually_inherited(true);
 
         carret->set_point(point::center, point::left, vector2f(text_insets_.left - 1.0f, 0.0f));
 

--- a/src/gui_edit_box.cpp
+++ b/src/gui_edit_box.cpp
@@ -256,22 +256,22 @@ void edit_box::highlight_text(std::size_t start, std::size_t end, bool force_upd
                     left = left - display_pos_;
 
                 float left_pos = text_insets_.left;
-                if (left < text->get_num_letters())
+                if (left < text->get_letter_count())
                     left_pos += text->get_letter_quad(left)[0].pos.x;
 
                 right           = right - display_pos_;
                 float right_pos = text_insets_.left;
                 if (right < displayed_text_.size()) {
-                    if (right < text->get_num_letters())
+                    if (right < text->get_letter_count())
                         right_pos += text->get_letter_quad(right)[0].pos.x;
                 } else {
                     right = displayed_text_.size() - 1;
-                    if (right < text->get_num_letters())
+                    if (right < text->get_letter_count())
                         right_pos += text->get_letter_quad(right)[2].pos.x;
                 }
 
-                highlight_->set_point(point::left, name_, vector2f(left_pos, 0));
-                highlight_->set_point(point::right, name_, point::left, vector2f(right_pos, 0));
+                highlight_->set_anchor(point::left, name_, vector2f(left_pos, 0));
+                highlight_->set_anchor(point::right, name_, point::left, vector2f(right_pos, 0));
 
                 highlight_->show();
             } else
@@ -358,7 +358,7 @@ std::size_t edit_box::get_max_letters() const {
     return max_letters_;
 }
 
-std::size_t edit_box::get_num_letters() const {
+std::size_t edit_box::get_letter_count() const {
     return unicode_text_.size();
 }
 
@@ -519,9 +519,9 @@ void edit_box::set_text_insets(const bounds2f& insets) {
     text_insets_ = insets;
 
     if (font_string_) {
-        font_string_->clear_all_points();
-        font_string_->set_point(point::top_left, text_insets_.top_left());
-        font_string_->set_point(point::bottom_right, -text_insets_.bottom_right());
+        font_string_->clear_all_anchors();
+        font_string_->set_anchor(point::top_left, text_insets_.top_left());
+        font_string_->set_anchor(point::bottom_right, -text_insets_.bottom_right());
 
         update_displayed_text_();
         update_font_string_();
@@ -572,10 +572,10 @@ void edit_box::set_font_string(utils::observer_ptr<font_string> fstr) {
     font_string_->set_word_wrap(is_multi_line_, is_multi_line_);
 
     font_string_->set_dimensions(vector2f(0, 0));
-    font_string_->clear_all_points();
+    font_string_->clear_all_anchors();
 
-    font_string_->set_point(point::top_left, text_insets_.top_left());
-    font_string_->set_point(point::bottom_right, -text_insets_.bottom_right());
+    font_string_->set_anchor(point::top_left, text_insets_.top_left());
+    font_string_->set_anchor(point::bottom_right, -text_insets_.bottom_right());
 
     font_string_->enable_formatting(false);
 
@@ -613,8 +613,8 @@ void edit_box::create_highlight_() {
 
     highlight->set_manually_inherited(true);
 
-    highlight->set_point(point::top, vector2f(0.0f, text_insets_.top));
-    highlight->set_point(point::bottom, vector2f(0.0f, -text_insets_.bottom));
+    highlight->set_anchor(point::top, vector2f(0.0f, text_insets_.top));
+    highlight->set_anchor(point::bottom, vector2f(0.0f, -text_insets_.bottom));
 
     highlight->set_solid_color(highlight_color_);
 
@@ -633,7 +633,7 @@ void edit_box::create_carret_() {
 
         carret->set_manually_inherited(true);
 
-        carret->set_point(point::center, point::left, vector2f(text_insets_.left - 1.0f, 0.0f));
+        carret->set_anchor(point::center, point::left, vector2f(text_insets_.left - 1.0f, 0.0f));
 
         carret->notify_loaded();
         carret_ = carret;
@@ -727,7 +727,7 @@ void edit_box::update_carret_position_() {
         default: p = point::left; break;
         }
 
-        carret_->set_point(point::center, p, vector2f(offset, 0.0f));
+        carret_->set_anchor(point::center, p, vector2f(offset, 0.0f));
     } else {
         text*                    text = font_string_->get_text_object();
         utils::ustring::iterator iter_display_carret;
@@ -784,22 +784,22 @@ void edit_box::update_carret_position_() {
                 displayed_text_.begin() + (iter_carret_pos_ - unicode_text_.begin()) - display_pos_;
         }
 
-        float y_offset = static_cast<float>((text->get_num_lines() - 1)) *
+        float y_offset = static_cast<float>((text->get_line_count() - 1)) *
                          (text->get_line_height() * text->get_line_spacing());
 
         std::size_t index = iter_display_carret - displayed_text_.begin();
 
         float x_offset = text_insets_.left;
         if (index < displayed_text_.size()) {
-            if (index < text->get_num_letters())
+            if (index < text->get_letter_count())
                 x_offset += text->get_letter_quad(index)[0].pos.x;
         } else {
             index = displayed_text_.size() - 1;
-            if (index < text->get_num_letters())
+            if (index < text->get_letter_count())
                 x_offset += text->get_letter_quad(index)[2].pos.x;
         }
 
-        carret_->set_point(point::center, point::left, vector2f(x_offset, y_offset));
+        carret_->set_anchor(point::center, point::left, vector2f(x_offset, y_offset));
     }
 
     carret_timer_.zero();
@@ -813,7 +813,7 @@ bool edit_box::add_char_(char32_t c) {
     if (is_text_selected_)
         remove_char_();
 
-    if (get_num_letters() >= max_letters_)
+    if (get_letter_count() >= max_letters_)
         return false;
 
     // TODO: use localizer for these checks, if possible
@@ -901,7 +901,7 @@ std::size_t edit_box::get_letter_id_at_(const vector2f& position) const {
             return displayed_text_.size() + display_pos_;
 
         std::size_t num_letters =
-            std::min<std::size_t>(text->get_num_letters(), displayed_text_.size());
+            std::min<std::size_t>(text->get_letter_count(), displayed_text_.size());
 
         for (std::size_t index = 0u; index < num_letters; ++index) {
             const auto& quad = text->get_letter_quad(index);
@@ -1006,7 +1006,7 @@ void edit_box::process_key_(key key_id, bool shift_is_pressed, bool ctrl_is_pres
         }
     } else if (key_id == key::k_end) {
         std::size_t previous_carret_pos = get_cursor_position();
-        set_cursor_position(get_num_letters());
+        set_cursor_position(get_letter_count());
 
         if (shift_is_pressed) {
             if (is_text_selected_)

--- a/src/gui_edit_box.cpp
+++ b/src/gui_edit_box.cpp
@@ -1118,4 +1118,8 @@ void edit_box::process_key_(key key_id, bool shift_is_pressed, bool ctrl_is_pres
     }
 }
 
+const std::vector<std::string>& edit_box::get_type_list_() const {
+    return get_type_list_impl_<edit_box>();
+}
+
 } // namespace lxgui::gui

--- a/src/gui_edit_box.cpp
+++ b/src/gui_edit_box.cpp
@@ -58,7 +58,7 @@ void edit_box::copy_from(const region& obj) {
 
     if (const font_string* fs = box_obj->get_font_string().get()) {
         region_core_attributes attr;
-        attr.name        = fs->get_name();
+        attr.name        = fs->get_raw_name();
         attr.inheritance = {box_obj->get_font_string()};
 
         auto fnt = this->create_layered_region<font_string>(fs->get_draw_layer(), std::move(attr));

--- a/src/gui_edit_box_glues.cpp
+++ b/src/gui_edit_box_glues.cpp
@@ -91,9 +91,9 @@ void edit_box::register_on_lua(sol::state& lua) {
      */
     type.set_function("get_max_letters", member_function<&edit_box::get_max_letters>());
 
-    /** @function get_num_letters
+    /** @function get_letter_count
      */
-    type.set_function("get_num_letters", member_function<&edit_box::get_num_letters>());
+    type.set_function("get_letter_count", member_function<&edit_box::get_letter_count>());
 
     /** @function get_number
      */

--- a/src/gui_edit_box_parser.cpp
+++ b/src/gui_edit_box_parser.cpp
@@ -53,7 +53,7 @@ void edit_box::parse_font_string_node_(const layout_node& node) {
 
         auto fstr = parse_region_(defaulted, "ARTWORK", "FontString");
         if (fstr) {
-            fstr->set_special();
+            fstr->set_manually_inherited(true);
             set_font_string(utils::static_pointer_cast<font_string>(fstr));
         }
 

--- a/src/gui_factory.cpp
+++ b/src/gui_factory.cpp
@@ -95,11 +95,11 @@ bool factory::finalize_object_(registry& reg, region& object, const region_core_
 
 void factory::apply_inheritance_(region& object, const region_core_attributes& attr) {
     for (const auto& base : attr.inheritance) {
-        if (!object.is_object_type(base->get_object_type())) {
+        if (!object.is_region_type(base->get_region_type())) {
             gui::out << gui::warning << "gui::factory: "
-                     << "\"" << object.get_name() << "\" (" << object.get_object_type()
+                     << "\"" << object.get_name() << "\" (" << object.get_region_type()
                      << ") cannot inherit from \"" << base->get_name() << "\" ("
-                     << base->get_object_type() << "). Inheritance skipped." << std::endl;
+                     << base->get_region_type() << "). Inheritance skipped." << std::endl;
             continue;
         }
 

--- a/src/gui_factory.cpp
+++ b/src/gui_factory.cpp
@@ -95,7 +95,7 @@ bool factory::finalize_object_(registry& reg, region& object, const region_core_
 
 void factory::apply_inheritance_(region& object, const region_core_attributes& attr) {
     for (const auto& base : attr.inheritance) {
-        if (!object.is_region_type(base->get_region_type())) {
+        if (!object.is_region_type(*base)) {
             gui::out << gui::warning << "gui::factory: "
                      << "\"" << object.get_name() << "\" (" << object.get_region_type()
                      << ") cannot inherit from \"" << base->get_name() << "\" ("

--- a/src/gui_font_string.cpp
+++ b/src/gui_font_string.cpp
@@ -491,4 +491,8 @@ void font_string::update_borders_() {
     DEBUG_LOG("  @");
 }
 
+const std::vector<std::string>& font_string::get_type_list_() const {
+    return get_type_list_impl_<font_string>();
+}
+
 } // namespace lxgui::gui

--- a/src/gui_font_string.cpp
+++ b/src/gui_font_string.cpp
@@ -28,22 +28,22 @@ void font_string::render() const {
 
     if (std::isinf(text_->get_box_width())) {
         switch (align_x_) {
-        case alignment_x::left: pos.x = border_list_.left; break;
-        case alignment_x::center: pos.x = (border_list_.left + border_list_.right) / 2; break;
-        case alignment_x::right: pos.x = border_list_.right; break;
+        case alignment_x::left: pos.x = borders_.left; break;
+        case alignment_x::center: pos.x = (borders_.left + borders_.right) / 2; break;
+        case alignment_x::right: pos.x = borders_.right; break;
         }
     } else {
-        pos.x = border_list_.left;
+        pos.x = borders_.left;
     }
 
     if (std::isinf(text_->get_box_height())) {
         switch (align_y_) {
-        case alignment_y::top: pos.y = border_list_.top; break;
-        case alignment_y::middle: pos.y = (border_list_.top + border_list_.bottom) / 2; break;
-        case alignment_y::bottom: pos.y = border_list_.bottom; break;
+        case alignment_y::top: pos.y = borders_.top; break;
+        case alignment_y::middle: pos.y = (borders_.top + borders_.bottom) / 2; break;
+        case alignment_y::bottom: pos.y = borders_.bottom; break;
         }
     } else {
-        pos.y = border_list_.top;
+        pos.y = borders_.top;
     }
 
     pos += offset_;
@@ -408,7 +408,7 @@ void font_string::update_borders_() {
 #define DEBUG_LOG(msg)
 
     const bool old_ready       = is_ready_;
-    const auto old_border_list = border_list_;
+    const auto old_border_list = borders_;
     is_ready_                  = true;
 
     if (!anchor_list_.empty()) {
@@ -421,13 +421,13 @@ void font_string::update_borders_() {
         float box_width = std::numeric_limits<float>::infinity();
         if (get_dimensions().x != 0.0f)
             box_width = get_dimensions().x;
-        else if (defined_border_list_.left && defined_border_list_.right)
+        else if (defined_borders_.left && defined_borders_.right)
             box_width = right - left;
 
         float box_height = std::numeric_limits<float>::infinity();
         if (get_dimensions().y != 0.0f)
             box_height = get_dimensions().y;
-        else if (defined_border_list_.top && defined_border_list_.bottom)
+        else if (defined_borders_.top && defined_borders_.bottom)
             box_height = bottom - top;
 
         box_width  = round_to_pixel(box_width, utils::rounding_method::nearest_not_zero);
@@ -457,12 +457,12 @@ void font_string::update_borders_() {
                 bottom = top + 1.0f;
             }
 
-            border_list_.left   = left;
-            border_list_.right  = right;
-            border_list_.top    = top;
-            border_list_.bottom = bottom;
+            borders_.left   = left;
+            borders_.right  = right;
+            borders_.top    = top;
+            borders_.bottom = bottom;
         } else {
-            border_list_ = bounds2f::zero;
+            borders_ = bounds2f::zero;
         }
     } else {
         float box_width = get_dimensions().x;
@@ -475,16 +475,16 @@ void font_string::update_borders_() {
             box_height = text_->get_height();
         }
 
-        border_list_ = bounds2f(0.0, 0.0, box_width, box_height);
-        is_ready_    = false;
+        borders_  = bounds2f(0.0, 0.0, box_width, box_height);
+        is_ready_ = false;
     }
 
-    border_list_.left   = round_to_pixel(border_list_.left);
-    border_list_.right  = round_to_pixel(border_list_.right);
-    border_list_.top    = round_to_pixel(border_list_.top);
-    border_list_.bottom = round_to_pixel(border_list_.bottom);
+    borders_.left   = round_to_pixel(borders_.left);
+    borders_.right  = round_to_pixel(borders_.right);
+    borders_.top    = round_to_pixel(borders_.top);
+    borders_.bottom = round_to_pixel(borders_.bottom);
 
-    if (border_list_ != old_border_list || is_ready_ != old_ready) {
+    if (borders_ != old_border_list || is_ready_ != old_ready) {
         DEBUG_LOG("  Fire redraw");
         notify_renderer_need_redraw();
     }

--- a/src/gui_frame.cpp
+++ b/src/gui_frame.cpp
@@ -770,21 +770,21 @@ vector2f frame::get_min_dimensions() const {
     return vector2f(min_width_, min_height_);
 }
 
-std::size_t frame::get_num_children() const {
+std::size_t frame::get_child_count() const {
     return std::count_if(
         child_list_.begin(), child_list_.end(), [](const auto& child) { return child != nullptr; });
 }
 
-std::size_t frame::get_rough_num_children() const {
+std::size_t frame::get_child_count_upper_bound() const {
     return child_list_.size();
 }
 
-std::size_t frame::get_num_regions() const {
+std::size_t frame::get_layered_region_count() const {
     return std::count_if(
         region_list_.begin(), region_list_.end(), [](const auto& reg) { return reg != nullptr; });
 }
 
-std::size_t frame::get_rough_num_regions() const {
+std::size_t frame::get_layered_region_count_upper_bound() const {
     return region_list_.size();
 }
 
@@ -983,7 +983,7 @@ utils::connection frame::define_script_(
         std::vector<sol::object> lua_args;
 
         // Set arguments
-        for (std::size_t i = 0; i < args.get_num_param(); ++i) {
+        for (std::size_t i = 0; i < args.get_param_count(); ++i) {
             const utils::variant& arg = args.get(i);
             if (std::holds_alternative<utils::empty>(arg))
                 lua_args.emplace_back(sol::lua_nil);
@@ -1076,7 +1076,7 @@ void frame::remove_script(const std::string& script_name) {
 void frame::on_event_(std::string_view event_name, const event_data& event) {
     event_data data;
     data.add(std::string(event_name));
-    for (std::size_t i = 0; i < event.get_num_param(); ++i)
+    for (std::size_t i = 0; i < event.get_param_count(); ++i)
         data.add(event.get(i));
 
     fire_script("OnEvent", data);

--- a/src/gui_frame.cpp
+++ b/src/gui_frame.cpp
@@ -5,6 +5,7 @@
 #include "lxgui/gui_backdrop.hpp"
 #include "lxgui/gui_event_emitter.hpp"
 #include "lxgui/gui_factory.hpp"
+#include "lxgui/gui_font_string.hpp"
 #include "lxgui/gui_frame_renderer.hpp"
 #include "lxgui/gui_layered_region.hpp"
 #include "lxgui/gui_manager.hpp"
@@ -1523,15 +1524,16 @@ void frame::update(float delta) {
             layer.region_list.clear();
 
         // Fill layers with regions (with font_string rendered last within the same layer)
+        // TODO: This is bad; the frame class should not know about font_string, see #.
         for (const auto& reg : region_list_) {
-            if (reg && !reg->is_region_type("font_string")) {
+            if (reg && !reg->is_region_type<font_string>()) {
                 layer_list_[static_cast<std::size_t>(reg->get_draw_layer())].region_list.push_back(
                     reg);
             }
         }
 
         for (const auto& reg : region_list_) {
-            if (reg && reg->is_region_type("font_string")) {
+            if (reg && reg->is_region_type<font_string>()) {
                 layer_list_[static_cast<std::size_t>(reg->get_draw_layer())].region_list.push_back(
                     reg);
             }
@@ -1588,6 +1590,10 @@ void frame::update(float delta) {
             }
         }
     }
+}
+
+const std::vector<std::string>& frame::get_type_list_() const {
+    return get_type_list_impl_<frame>();
 }
 
 } // namespace lxgui::gui

--- a/src/gui_frame.cpp
+++ b/src/gui_frame.cpp
@@ -355,62 +355,62 @@ void frame::set_height(float abs_height) {
 }
 
 void frame::check_position_() {
-    if (border_list_.right - border_list_.left < min_width_) {
-        border_list_.right = border_list_.left + min_width_;
-    } else if (border_list_.right - border_list_.left > max_width_) {
-        border_list_.right = border_list_.left + max_width_;
+    if (borders_.right - borders_.left < min_width_) {
+        borders_.right = borders_.left + min_width_;
+    } else if (borders_.right - borders_.left > max_width_) {
+        borders_.right = borders_.left + max_width_;
     }
 
-    if (border_list_.bottom - border_list_.top < min_height_) {
-        border_list_.bottom = border_list_.top + min_height_;
-    } else if (border_list_.bottom - border_list_.top > max_height_) {
-        border_list_.bottom = border_list_.top + max_height_;
+    if (borders_.bottom - borders_.top < min_height_) {
+        borders_.bottom = borders_.top + min_height_;
+    } else if (borders_.bottom - borders_.top > max_height_) {
+        borders_.bottom = borders_.top + max_height_;
     }
 
     if (is_clamped_to_screen_) {
         vector2f screen_dimensions = get_effective_frame_renderer()->get_target_dimensions();
 
-        if (border_list_.right > screen_dimensions.x) {
-            float width = border_list_.right - border_list_.left;
+        if (borders_.right > screen_dimensions.x) {
+            float width = borders_.right - borders_.left;
             if (width > screen_dimensions.x) {
-                border_list_.left  = 0;
-                border_list_.right = screen_dimensions.x;
+                borders_.left  = 0;
+                borders_.right = screen_dimensions.x;
             } else {
-                border_list_.right = screen_dimensions.x;
-                border_list_.left  = screen_dimensions.x - width;
+                borders_.right = screen_dimensions.x;
+                borders_.left  = screen_dimensions.x - width;
             }
         }
 
-        if (border_list_.left < 0) {
-            float width = border_list_.right - border_list_.left;
-            if (border_list_.right - border_list_.left > screen_dimensions.x) {
-                border_list_.left  = 0;
-                border_list_.right = screen_dimensions.x;
+        if (borders_.left < 0) {
+            float width = borders_.right - borders_.left;
+            if (borders_.right - borders_.left > screen_dimensions.x) {
+                borders_.left  = 0;
+                borders_.right = screen_dimensions.x;
             } else {
-                border_list_.left  = 0;
-                border_list_.right = width;
+                borders_.left  = 0;
+                borders_.right = width;
             }
         }
 
-        if (border_list_.bottom > screen_dimensions.y) {
-            float height = border_list_.bottom - border_list_.top;
+        if (borders_.bottom > screen_dimensions.y) {
+            float height = borders_.bottom - borders_.top;
             if (height > screen_dimensions.y) {
-                border_list_.top    = 0;
-                border_list_.bottom = screen_dimensions.y;
+                borders_.top    = 0;
+                borders_.bottom = screen_dimensions.y;
             } else {
-                border_list_.bottom = screen_dimensions.y;
-                border_list_.top    = screen_dimensions.y - height;
+                borders_.bottom = screen_dimensions.y;
+                borders_.top    = screen_dimensions.y - height;
             }
         }
 
-        if (border_list_.top < 0) {
-            float height = border_list_.bottom - border_list_.top;
+        if (borders_.top < 0) {
+            float height = borders_.bottom - borders_.top;
             if (height > screen_dimensions.y) {
-                border_list_.top    = 0;
-                border_list_.bottom = screen_dimensions.y;
+                borders_.top    = 0;
+                borders_.bottom = screen_dimensions.y;
             } else {
-                border_list_.top    = 0;
-                border_list_.bottom = height;
+                borders_.top    = 0;
+                borders_.bottom = height;
             }
         }
     }
@@ -804,10 +804,10 @@ bool frame::is_in_region(const vector2f& position) const {
     if (title_region_ && title_region_->is_in_region(position))
         return true;
 
-    bool is_in_x_range = border_list_.left + abs_hit_rect_inset_list_.left <= position.x &&
-                         position.x <= border_list_.right - abs_hit_rect_inset_list_.right - 1.0f;
-    bool is_in_y_range = border_list_.top + abs_hit_rect_inset_list_.top <= position.y &&
-                         position.y <= border_list_.bottom - abs_hit_rect_inset_list_.bottom - 1.0f;
+    bool is_in_x_range = borders_.left + abs_hit_rect_inset_list_.left <= position.x &&
+                         position.x <= borders_.right - abs_hit_rect_inset_list_.right - 1.0f;
+    bool is_in_y_range = borders_.top + abs_hit_rect_inset_list_.top <= position.y &&
+                         position.y <= borders_.bottom - abs_hit_rect_inset_list_.bottom - 1.0f;
 
     return is_in_x_range && is_in_y_range;
 }
@@ -1504,15 +1504,15 @@ void frame::notify_mouse_in_frame(bool mouse_in_frame, const vector2f& /*positio
 
 void frame::update_borders_() {
     const bool old_ready       = is_ready_;
-    const auto old_border_list = border_list_;
+    const auto old_border_list = borders_;
 
     base::update_borders_();
 
     check_position_();
 
-    if (border_list_ != old_border_list || is_ready_ != old_ready) {
-        if (border_list_.width() != old_border_list.width() ||
-            border_list_.height() != old_border_list.height()) {
+    if (borders_ != old_border_list || is_ready_ != old_ready) {
+        if (borders_.width() != old_border_list.width() ||
+            borders_.height() != old_border_list.height()) {
             alive_checker checker(*this);
             fire_script("OnSizeChanged");
             if (!checker.is_alive())

--- a/src/gui_frame.cpp
+++ b/src/gui_frame.cpp
@@ -227,7 +227,7 @@ void frame::copy_from(const region& obj) {
     this->set_scale(frame_obj->get_scale());
 
     for (const auto& art : frame_obj->region_list_) {
-        if (!art || art->is_special())
+        if (!art || art->is_manually_inherited())
             continue;
 
         region_core_attributes attr;
@@ -254,7 +254,7 @@ void frame::copy_from(const region& obj) {
     }
 
     for (const auto& child : frame_obj->child_list_) {
-        if (!child || child->is_special())
+        if (!child || child->is_manually_inherited())
             continue;
 
         frame_core_attributes attr;
@@ -288,7 +288,7 @@ void frame::create_title_region() {
     if (!title_region)
         return;
 
-    title_region->set_special();
+    title_region->set_manually_inherited(true);
 
     if (!title_region->is_virtual()) {
         // Add shortcut to region as entry in Lua table

--- a/src/gui_frame.cpp
+++ b/src/gui_frame.cpp
@@ -1415,7 +1415,7 @@ void frame::notify_visible() {
     if (!checker.is_alive())
         return;
 
-    notify_renderer_need_redraw();
+    get_manager().get_root().notify_hovered_frame_dirty();
 }
 
 void frame::notify_invisible() {
@@ -1439,7 +1439,7 @@ void frame::notify_invisible() {
     if (!checker.is_alive())
         return;
 
-    notify_renderer_need_redraw();
+    get_manager().get_root().notify_hovered_frame_dirty();
 }
 
 void frame::notify_renderer_need_redraw() {
@@ -1460,28 +1460,6 @@ void frame::notify_scaling_factor_updated() {
 
     for (auto& obj : get_regions())
         obj.notify_scaling_factor_updated();
-}
-
-void frame::show() {
-    if (is_shown_)
-        return;
-
-    bool was_visible = is_visible_;
-    base::show();
-
-    if (!was_visible)
-        get_manager().get_root().notify_hovered_frame_dirty();
-}
-
-void frame::hide() {
-    if (!is_shown_)
-        return;
-
-    bool was_visible = is_visible_;
-    base::hide();
-
-    if (was_visible)
-        get_manager().get_root().notify_hovered_frame_dirty();
 }
 
 void frame::notify_mouse_in_frame(bool mouse_in_frame, const vector2f& /*position*/) {

--- a/src/gui_frame.cpp
+++ b/src/gui_frame.cpp
@@ -922,11 +922,23 @@ std::string hijack_sol_error_message(
     return new_error;
 }
 
+bool frame::check_script_(const std::string& script_name) const {
+    if (!can_use_script(script_name)) {
+        gui::out << gui::error << get_region_type() << ": "
+                 << "\"" << get_name() << "\" cannot use script \"" << script_name << "\"."
+                 << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
 utils::connection frame::define_script_(
     const std::string& script_name,
     const std::string& content,
     bool               append,
     const script_info& info) {
+
     // Create the Lua function from the provided string
     sol::state& lua = get_lua_();
 
@@ -1003,6 +1015,7 @@ utils::connection frame::define_script_(
     script_function    handler,
     bool               append,
     const script_info& /*info*/) {
+
     if (!is_virtual()) {
         // Register the function so it can be called directly from Lua
         std::string adjusted_name = get_adjusted_script_name(script_name);

--- a/src/gui_frame.cpp
+++ b/src/gui_frame.cpp
@@ -24,7 +24,6 @@ namespace lxgui::gui {
 
 frame::frame(utils::control_block& block, manager& mgr, const frame_core_attributes& attr) :
     base(block, mgr, attr), event_receiver_(mgr.get_event_emitter()), frame_renderer_(attr.rdr) {
-    type_.push_back(class_name);
 
     initialize_(*this, attr);
 
@@ -231,7 +230,7 @@ void frame::copy_from(const region& obj) {
             continue;
 
         region_core_attributes attr;
-        attr.object_type = art->get_object_type();
+        attr.object_type = art->get_region_type();
         attr.name        = art->get_raw_name();
         attr.inheritance = {art};
 
@@ -258,7 +257,7 @@ void frame::copy_from(const region& obj) {
             continue;
 
         frame_core_attributes attr;
-        attr.object_type = child->get_object_type();
+        attr.object_type = child->get_region_type();
         attr.name        = child->get_raw_name();
         attr.inheritance = {child};
 
@@ -272,7 +271,7 @@ void frame::copy_from(const region& obj) {
 
 void frame::create_title_region() {
     if (title_region_) {
-        gui::out << gui::warning << "gui::" << type_.back() << ": \"" << name_
+        gui::out << gui::warning << "gui::" << get_region_type() << ": \"" << name_
                  << "\" already has a title region." << std::endl;
         return;
     }
@@ -602,7 +601,7 @@ frame::remove_region(const utils::observer_ptr<layered_region>& reg) {
     auto iter = utils::find_if(region_list_, [&](auto& obj) { return obj.get() == raw_pointer; });
 
     if (iter == region_list_.end()) {
-        gui::out << gui::warning << "gui::" << type_.back() << ": "
+        gui::out << gui::warning << "gui::" << get_region_type() << ": "
                  << "Trying to remove \"" << reg->get_name() << "\" from \"" << name_
                  << "\"'s children, but it was not one of this frame's children." << std::endl;
         return nullptr;
@@ -675,7 +674,7 @@ utils::owner_ptr<frame> frame::remove_child(const utils::observer_ptr<frame>& ch
     auto   iter = utils::find_if(child_list_, [&](auto& obj) { return obj.get() == raw_pointer; });
 
     if (iter == child_list_.end()) {
-        gui::out << gui::warning << "gui::" << type_.back() << ": "
+        gui::out << gui::warning << "gui::" << get_region_type() << ": "
                  << "Trying to remove \"" << child->get_name() << "\" from \"" << name_
                  << "\"'s children, but it was not one of this frame's children." << std::endl;
         return nullptr;
@@ -752,10 +751,6 @@ backdrop& frame::get_or_create_backdrop() {
         backdrop_ = std::unique_ptr<backdrop>(new backdrop(*this));
 
     return *backdrop_;
-}
-
-const std::string& frame::get_frame_type() const {
-    return type_.back();
 }
 
 const bounds2f& frame::get_abs_hit_rect_insets() const {
@@ -1043,7 +1038,7 @@ utils::connection frame::define_script_(
 script_list_view frame::get_script(const std::string& script_name) const {
     auto iter_h = signal_list_.find(script_name);
     if (iter_h == signal_list_.end())
-        throw gui::exception(type_.back(), "no script registered for " + script_name);
+        throw gui::exception(get_region_type(), "no script registered for " + script_name);
 
     return iter_h->second.slots();
 }
@@ -1516,14 +1511,14 @@ void frame::update(float delta) {
 
         // Fill layers with regions (with font_string rendered last within the same layer)
         for (const auto& reg : region_list_) {
-            if (reg && !reg->is_object_type("font_string")) {
+            if (reg && !reg->is_region_type("font_string")) {
                 layer_list_[static_cast<std::size_t>(reg->get_draw_layer())].region_list.push_back(
                     reg);
             }
         }
 
         for (const auto& reg : region_list_) {
-            if (reg && reg->is_object_type("font_string")) {
+            if (reg && reg->is_region_type("font_string")) {
                 layer_list_[static_cast<std::size_t>(reg->get_draw_layer())].region_list.push_back(
                     reg);
             }

--- a/src/gui_frame.cpp
+++ b/src/gui_frame.cpp
@@ -292,8 +292,8 @@ void frame::create_title_region() {
 
     if (!title_region->is_virtual()) {
         // Add shortcut to region as entry in Lua table
-        auto& lua                          = get_lua_();
-        lua[get_lua_name()]["TitleRegion"] = lua[title_region->get_lua_name()];
+        auto& lua                      = get_lua_();
+        lua[get_name()]["TitleRegion"] = lua[title_region->get_name()];
     }
 
     title_region_ = std::move(title_region);
@@ -498,8 +498,8 @@ void frame::set_parent_(utils::observer_ptr<frame> parent) {
             std::string raw_name = get_raw_name();
             if (utils::starts_with(raw_name, "$parent")) {
                 raw_name.erase(0, std::string("$parent").size());
-                sol::state& lua                                = get_lua_();
-                lua[raw_prev_parent->get_lua_name()][raw_name] = sol::lua_nil;
+                sol::state& lua                            = get_lua_();
+                lua[raw_prev_parent->get_name()][raw_name] = sol::lua_nil;
             }
         }
     }
@@ -525,8 +525,8 @@ void frame::set_parent_(utils::observer_ptr<frame> parent) {
             std::string raw_name = get_raw_name();
             if (utils::starts_with(raw_name, "$parent")) {
                 raw_name.erase(0, std::string("$parent").size());
-                auto& lua                                     = get_lua_();
-                lua[raw_new_parent->get_lua_name()][raw_name] = lua[get_lua_name()];
+                auto& lua                                 = get_lua_();
+                lua[raw_new_parent->get_name()][raw_name] = lua[get_name()];
             }
         }
 
@@ -584,8 +584,8 @@ utils::observer_ptr<layered_region> frame::add_region(utils::owner_ptr<layered_r
         std::string raw_name = added_region->get_raw_name();
         if (utils::starts_with(raw_name, "$parent")) {
             raw_name.erase(0, std::string("$parent").size());
-            auto& lua                     = get_lua_();
-            lua[get_lua_name()][raw_name] = lua[added_region->get_lua_name()];
+            auto& lua                 = get_lua_();
+            lua[get_name()][raw_name] = lua[added_region->get_name()];
         }
     }
 
@@ -620,8 +620,8 @@ frame::remove_region(const utils::observer_ptr<layered_region>& reg) {
         std::string raw_name = removed_region->get_raw_name();
         if (utils::starts_with(raw_name, "$parent")) {
             raw_name.erase(0, std::string("$parent").size());
-            sol::state& lua               = get_lua_();
-            lua[get_lua_name()][raw_name] = sol::lua_nil;
+            sol::state& lua           = get_lua_();
+            lua[get_name()][raw_name] = sol::lua_nil;
         }
     }
 
@@ -984,7 +984,7 @@ utils::connection frame::define_script_(
         }
 
         // Get a reference to self
-        sol::object self_lua = lua[self.get_lua_name()];
+        sol::object self_lua = lua[self.get_name()];
         if (self_lua == sol::lua_nil)
             throw gui::exception("Lua glue object is nil");
 
@@ -1012,7 +1012,7 @@ utils::connection frame::define_script_(
         // Register the function so it can be called directly from Lua
         std::string adjusted_name = get_adjusted_script_name(script_name);
 
-        get_lua_()[get_lua_name()][adjusted_name].set_function(
+        get_lua_()[get_name()][adjusted_name].set_function(
             [=](frame& self, sol::variadic_args v_args) {
                 event_data data;
                 for (auto&& arg : v_args) {
@@ -1059,8 +1059,8 @@ void frame::remove_script(const std::string& script_name) {
     iter_h->second.disconnect_all();
 
     if (!is_virtual()) {
-        std::string adjusted_name                 = get_adjusted_script_name(script_name);
-        get_lua_()[get_lua_name()][adjusted_name] = sol::lua_nil;
+        std::string adjusted_name             = get_adjusted_script_name(script_name);
+        get_lua_()[get_name()][adjusted_name] = sol::lua_nil;
     }
 }
 

--- a/src/gui_frame_glues.cpp
+++ b/src/gui_frame_glues.cpp
@@ -415,7 +415,7 @@ void frame::register_on_lua(sol::state& lua) {
      */
     type.set_function("get_children", [](sol::this_state this_lua, const frame& self) {
         std::vector<sol::object> children;
-        children.reserve(self.get_rough_num_children());
+        children.reserve(self.get_child_count_upper_bound());
 
         auto lua_state = sol::state_view(this_lua);
         for (const auto& child : self.get_children()) {
@@ -474,13 +474,14 @@ void frame::register_on_lua(sol::state& lua) {
         return std::make_tuple(min.x, min.y);
     });
 
-    /** @function get_num_children
+    /** @function get_child_count
      */
-    type.set_function("get_num_children", member_function<&frame::get_num_children>());
+    type.set_function("get_child_count", member_function<&frame::get_child_count>());
 
-    /** @function get_num_regions
+    /** @function get_layered_region_count
      */
-    type.set_function("get_num_regions", member_function<&frame::get_num_regions>());
+    type.set_function(
+        "get_layered_region_count", member_function<&frame::get_layered_region_count>());
 
     /** @function get_scale
      */

--- a/src/gui_frame_glues.cpp
+++ b/src/gui_frame_glues.cpp
@@ -419,7 +419,7 @@ void frame::register_on_lua(sol::state& lua) {
 
         auto lua_state = sol::state_view(this_lua);
         for (const auto& child : self.get_children()) {
-            children.push_back(lua_state[child.get_lua_name()]);
+            children.push_back(lua_state[child.get_name()]);
         }
 
         return sol::as_table(std::move(children));
@@ -498,7 +498,7 @@ void frame::register_on_lua(sol::state& lua) {
                 return sol::lua_nil;
 
             std::string adjusted_name = get_adjusted_script_name(script_name);
-            return self.get_manager().get_lua()[self.get_lua_name()][adjusted_name];
+            return self.get_manager().get_lua()[self.get_name()][adjusted_name];
         });
 
     /** @function get_title_region

--- a/src/gui_frame_glues.cpp
+++ b/src/gui_frame_glues.cpp
@@ -120,12 +120,12 @@
  * is hidden indirectly (for example if its parent is itself hidden). This
  * will only fire if the frame was previously shown.
  * - `OnKeyDown`: Triggered when a keyboard key is pressed. Will only
- * trigger if the frame has focus (see @ref frame::set_focus) or if the key has
- * been registered for capture using @ref frame::enable_key_capture. If no
+ * trigger if the frame has focus (see @{Frame:set_focus}) or if the key has
+ * been registered for capture using @{Frame:enable_key_capture}. If no
  * keyboard-enabled frame is focused, only the topmost frame with
- * @ref frame::enable_key_capture will receive the event. If no frame has
+ * @{Frame:enable_key_capture} will receive the event. If no frame has
  * captured the key, then the key is tested for existing key bindings (see
- * @ref key_binder). This event provides five arguments to the registered
+ * @{Manager.register_key_binding}). This event provides five arguments to the registered
  * callback: a number identifying the main key being pressed, three boolean flags
  * for "Shift", "Ctrl", and "Alt, and finally the human-readable name of the
  * key combination being pressed (e.g., Shift+A).

--- a/src/gui_frame_glues.cpp
+++ b/src/gui_frame_glues.cpp
@@ -453,10 +453,6 @@ void frame::register_on_lua(sol::state& lua) {
         return utils::to_string(self.get_effective_frame_strata());
     });
 
-    /** @function get_frame_type
-     */
-    type.set_function("get_frame_type", member_function<&frame::get_frame_type>());
-
     /** @function get_hit_rect_insets
      */
     type.set_function("get_hit_rect_insets", [](const frame& self) {
@@ -519,12 +515,6 @@ void frame::register_on_lua(sol::state& lua) {
     /** @function is_clamped_to_screen
      */
     type.set_function("is_clamped_to_screen", member_function<&frame::is_clamped_to_screen>());
-
-    /** @function is_frame_type
-     */
-    type.set_function("is_frame_type", [](const frame& self, const std::string& type_name) {
-        return self.is_object_type(type_name);
-    });
 
     /** @function is_mouse_click_enabled
      */

--- a/src/gui_frame_glues.cpp
+++ b/src/gui_frame_glues.cpp
@@ -730,13 +730,6 @@ void frame::register_on_lua(sol::state& lua) {
     type.set_function(
         "set_script", [](frame& self, const std::string& script_name,
                          sol::optional<sol::protected_function> script) {
-            if (!self.can_use_script(script_name)) {
-                gui::out << gui::error << self.get_frame_type() << ": "
-                         << "\"" << self.get_name() << "\" cannot use script \"" << script_name
-                         << "\"." << std::endl;
-                return;
-            }
-
             if (script.has_value())
                 self.set_script(script_name, script.value());
             else

--- a/src/gui_frame_parser.cpp
+++ b/src/gui_frame_parser.cpp
@@ -33,8 +33,8 @@ void frame::parse_attributes_(const layout_node& node) {
     if (const layout_attribute* attr = node.try_get_attribute("hidden"))
         set_shown(!attr->get_value<bool>());
 
-    if (node.get_attribute_value_or<bool>("setAllPoints", false))
-        set_all_points("$parent");
+    if (node.get_attribute_value_or<bool>("setAllAnchors", false))
+        set_all_anchors("$parent");
 
     if (const layout_attribute* attr = node.try_get_attribute("alpha"))
         set_alpha(attr->get_value<float>());

--- a/src/gui_layered_region.cpp
+++ b/src/gui_layered_region.cpp
@@ -52,4 +52,8 @@ void layered_region::notify_renderer_need_redraw() {
         parent_->notify_renderer_need_redraw();
 }
 
+const std::vector<std::string>& layered_region::get_type_list_() const {
+    return get_type_list_impl_<layered_region>();
+}
+
 } // namespace lxgui::gui

--- a/src/gui_layered_region.cpp
+++ b/src/gui_layered_region.cpp
@@ -32,24 +32,6 @@ utils::owner_ptr<region> layered_region::release_from_parent() {
     return parent_->remove_region(utils::static_pointer_cast<layered_region>(observer_from_this()));
 }
 
-void layered_region::show() {
-    if (!is_shown_) {
-        is_shown_ = true;
-        notify_renderer_need_redraw();
-    }
-}
-
-void layered_region::hide() {
-    if (is_shown_) {
-        is_shown_ = false;
-        notify_renderer_need_redraw();
-    }
-}
-
-bool layered_region::is_visible() const {
-    return parent_->is_visible() && is_shown_;
-}
-
 layer layered_region::get_draw_layer() const {
     return layer_;
 }

--- a/src/gui_layered_region_parser.cpp
+++ b/src/gui_layered_region_parser.cpp
@@ -17,8 +17,8 @@ void layered_region::parse_attributes_(const layout_node& node) {
     if (const layout_attribute* attr = node.try_get_attribute("hidden"))
         set_shown(attr->get_value<bool>());
 
-    if (node.get_attribute_value_or<bool>("setAllPoints", false))
-        set_all_points("$parent");
+    if (node.get_attribute_value_or<bool>("setAllAnchors", false))
+        set_all_anchors("$parent");
 }
 
 } // namespace lxgui::gui

--- a/src/gui_manager_glues.cpp
+++ b/src/gui_manager_glues.cpp
@@ -37,6 +37,8 @@ void manager::create_lua_() {
 
     auto& lua = *lua_;
 
+    lua.globals()["_METADATA_"] = sol::table(lua.lua_state(), sol::create);
+
     /** @function log
      */
     lua.set_function("log", [](const std::string& message) { gui::out << message << std::endl; });

--- a/src/gui_manager_glues.cpp
+++ b/src/gui_manager_glues.cpp
@@ -64,7 +64,7 @@ void manager::create_lua_() {
             if (new_frame) {
                 new_frame->set_addon(get_addon_registry()->get_current_addon());
                 new_frame->notify_loaded();
-                return get_lua()[new_frame->get_lua_name()];
+                return get_lua()[new_frame->get_name()];
             } else
                 return sol::lua_nil;
         });

--- a/src/gui_manager_glues.cpp
+++ b/src/gui_manager_glues.cpp
@@ -37,7 +37,9 @@ void manager::create_lua_() {
 
     auto& lua = *lua_;
 
-    lua.globals()["_METADATA_"] = sol::table(lua.lua_state(), sol::create);
+    // This table is used to store Lua members of regions.
+    // See region::set_lua_member_.
+    lua.globals()["_METADATA"] = sol::table(lua.lua_state(), sol::create);
 
     /** @function log
      */

--- a/src/gui_region.cpp
+++ b/src/gui_region.cpp
@@ -397,10 +397,10 @@ bool check_cyclic_anchors(const region& self, anchor& a) {
     return true;
 }
 
-void region::set_all_points(const std::string& obj_name) {
+void region::set_all_anchors(const std::string& obj_name) {
     if (obj_name == name_) {
         gui::out << gui::error << "gui::" << get_region_type()
-                 << ": Cannot call set_all_points(this)." << std::endl;
+                 << ": Cannot call set_all_anchors(this)." << std::endl;
         return;
     }
 
@@ -430,14 +430,14 @@ void region::set_all_points(const std::string& obj_name) {
     }
 }
 
-void region::set_all_points(const utils::observer_ptr<region>& obj) {
+void region::set_all_anchors(const utils::observer_ptr<region>& obj) {
     if (obj == observer_from_this()) {
         gui::out << gui::error << "gui::" << get_region_type()
-                 << ": Cannot call set_all_points(this)." << std::endl;
+                 << ": Cannot call set_all_anchors(this)." << std::endl;
         return;
     }
 
-    set_all_points(obj ? obj->get_name() : "");
+    set_all_anchors(obj ? obj->get_name() : "");
 }
 
 void set_defined_borders(bounds2<bool>& defined_borders, point p, bool defined) {

--- a/src/gui_region.cpp
+++ b/src/gui_region.cpp
@@ -148,11 +148,12 @@ const std::string& region::get_raw_name() const {
 }
 
 const std::string& region::get_region_type() const {
-    return type_.back();
+    return get_type_list_().back();
 }
 
 bool region::is_region_type(const std::string& type_name) const {
-    return utils::find(type_, type_name) != type_.end();
+    const auto& type_list = get_type_list_();
+    return utils::find(type_list, type_name) != type_list.end();
 }
 
 float region::get_alpha() const {
@@ -834,6 +835,10 @@ registry& region::get_registry() {
 const registry& region::get_registry() const {
     return is_virtual() ? get_manager().get_virtual_root().get_registry()
                         : get_manager().get_root().get_registry();
+}
+
+const std::vector<std::string>& region::get_type_list_() const {
+    return get_type_list_impl_<region>();
 }
 
 } // namespace lxgui::gui

--- a/src/gui_region.cpp
+++ b/src/gui_region.cpp
@@ -789,10 +789,12 @@ utils::observer_ptr<const frame_renderer> region::get_effective_frame_renderer()
 
 void region::notify_visible() {
     is_visible_ = true;
+    notify_renderer_need_redraw();
 }
 
 void region::notify_invisible() {
     is_visible_ = false;
+    notify_renderer_need_redraw();
 }
 
 std::string region::parse_file_name(const std::string& file_name) const {

--- a/src/gui_region.cpp
+++ b/src/gui_region.cpp
@@ -93,9 +93,9 @@ region::~region() {
 std::string region::serialize(const std::string& tab) const {
     std::ostringstream str;
 
-    str << tab << "  # Name       : " << name_
-        << " (" + std::string(is_ready_ ? "ready" : "not ready") +
-               std::string(is_special_ ? ", special)\n" : ")\n");
+    str << tab << "  # Name       : " << name_ << " ("
+        << std::string(is_ready_ ? "ready" : "not ready")
+        << std::string(is_manually_inherited_ ? ", manually inherited" : "") << ")\n";
     str << tab << "  # Raw name   : " << raw_name_ << "\n";
     str << tab << "  # Lua name   : " << lua_name_ << "\n";
     str << tab << "  # Type       : " << type_.back() << "\n";
@@ -767,12 +767,12 @@ void region::remove_glue() {
     get_lua_().globals()[lua_name_] = sol::lua_nil;
 }
 
-void region::set_special() {
-    is_special_ = true;
+void region::set_manually_inherited(bool manually_inherited) {
+    is_manually_inherited_ = manually_inherited;
 }
 
-bool region::is_special() const {
-    return is_special_;
+bool region::is_manually_inherited() const {
+    return is_manually_inherited_;
 }
 
 void region::notify_renderer_need_redraw() {}

--- a/src/gui_region.cpp
+++ b/src/gui_region.cpp
@@ -753,8 +753,13 @@ sol::state& region::get_lua_() {
     return get_manager().get_lua();
 }
 
+const sol::state& region::get_lua_() const {
+    return get_manager().get_lua();
+}
+
 void region::remove_glue() {
-    get_lua_().globals()[get_name()] = sol::lua_nil;
+    get_lua_().globals()[get_name()]               = sol::lua_nil;
+    get_lua_().globals()["_METADATA_"][get_name()] = sol::lua_nil;
 }
 
 void region::set_manually_inherited(bool manually_inherited) {

--- a/src/gui_region.cpp
+++ b/src/gui_region.cpp
@@ -97,7 +97,6 @@ std::string region::serialize(const std::string& tab) const {
         << std::string(is_ready_ ? "ready" : "not ready")
         << std::string(is_manually_inherited_ ? ", manually inherited" : "") << ")\n";
     str << tab << "  # Raw name   : " << raw_name_ << "\n";
-    str << tab << "  # Lua name   : " << lua_name_ << "\n";
     str << tab << "  # Type       : " << type_.back() << "\n";
     if (parent_)
         str << tab << "  # Parent     : " << parent_->get_name() << "\n";
@@ -142,10 +141,6 @@ void region::copy_from(const region& obj) {
 
 const std::string& region::get_name() const {
     return name_;
-}
-
-const std::string& region::get_lua_name() const {
-    return lua_name_;
 }
 
 const std::string& region::get_raw_name() const {
@@ -299,19 +294,16 @@ bool region::is_in_region(const vector2f& position) const {
 
 void region::set_name_(const std::string& name) {
     if (name_.empty()) {
-        name_ = lua_name_ = raw_name_ = name;
+        name_ = raw_name_ = name;
         if (utils::starts_with(name_, "$parent")) {
             if (parent_)
-                utils::replace(lua_name_, "$parent", parent_->get_lua_name());
+                utils::replace(name_, "$parent", parent_->get_name());
             else {
                 gui::out << gui::warning << "gui::" << type_.back() << ": \"" << name_
                          << "\" has no parent" << std::endl;
-                utils::replace(lua_name_, "$parent", "");
+                utils::replace(name_, "$parent", "");
             }
         }
-
-        if (!is_virtual_)
-            name_ = lua_name_;
     } else {
         gui::out << gui::warning << "gui::" << type_.back() << ": "
                  << "set_name() can only be called once." << std::endl;
@@ -764,7 +756,7 @@ sol::state& region::get_lua_() {
 }
 
 void region::remove_glue() {
-    get_lua_().globals()[lua_name_] = sol::lua_nil;
+    get_lua_().globals()[get_name()] = sol::lua_nil;
 }
 
 void region::set_manually_inherited(bool manually_inherited) {

--- a/src/gui_region.cpp
+++ b/src/gui_region.cpp
@@ -54,13 +54,13 @@ region::~region() {
                 continue;
 
             std::vector<point> anchored_point_list;
-            for (const auto& a : obj->get_point_list()) {
+            for (const auto& a : obj->get_anchors()) {
                 if (a && a->get_parent().get() == this)
                     anchored_point_list.push_back(a->object_point);
             }
 
             for (const auto& p : anchored_point_list) {
-                const anchor& a          = obj->get_point(p);
+                const anchor& a          = obj->get_anchor(p);
                 anchor_data   new_anchor = anchor_data(p, "", point::top_left);
                 new_anchor.offset        = a.offset;
 
@@ -76,7 +76,7 @@ region::~region() {
                 case point::center: new_anchor.offset += borders_.center(); break;
                 }
 
-                obj->set_point(new_anchor);
+                obj->set_anchor(new_anchor);
             }
         }
 
@@ -100,7 +100,7 @@ std::string region::serialize(const std::string& tab) const {
         str << tab << "  # Parent     : " << parent_->get_name() << "\n";
     else
         str << tab << "  # Parent     : none\n";
-    str << tab << "  # Num anchors: " << get_num_point() << "\n";
+    str << tab << "  # Num anchors: " << get_anchor_count() << "\n";
     if (!anchor_list_.empty()) {
         str << tab << "  |-###\n";
         for (const auto& a : anchor_list_) {
@@ -130,9 +130,9 @@ void region::copy_from(const region& obj) {
     this->set_shown(obj.is_shown());
     this->set_dimensions(obj.get_dimensions());
 
-    for (const std::optional<anchor>& a : obj.get_point_list()) {
+    for (const std::optional<anchor>& a : obj.get_anchors()) {
         if (a) {
-            this->set_point(a->get_data());
+            this->set_anchor(a->get_data());
         }
     }
 }
@@ -358,7 +358,7 @@ const bounds2f& region::get_borders() const {
     return borders_;
 }
 
-void region::clear_all_points() {
+void region::clear_all_anchors() {
     bool had_anchors = false;
     for (auto& a : anchor_list_) {
         if (a) {
@@ -404,7 +404,7 @@ void region::set_all_points(const std::string& obj_name) {
         return;
     }
 
-    clear_all_points();
+    clear_all_anchors();
 
     auto& top_left     = anchor_list_[static_cast<int>(point::top_left)];
     auto& bottom_right = anchor_list_[static_cast<int>(point::bottom_right)];
@@ -466,7 +466,7 @@ void set_defined_borders(bounds2<bool>& defined_borders, point p, bool defined) 
     }
 }
 
-void region::set_point(const anchor_data& a) {
+void region::set_anchor(const anchor_data& a) {
     auto& modified_anchor = anchor_list_[static_cast<int>(a.object_point)];
     auto  previous_parent = modified_anchor.has_value() ? modified_anchor->get_parent() : nullptr;
 
@@ -512,7 +512,7 @@ bool region::depends_on(const region& obj) const {
     return false;
 }
 
-std::size_t region::get_num_point() const {
+std::size_t region::get_anchor_count() const {
     std::size_t num_anchors = 0u;
     for (const auto& a : anchor_list_) {
         if (a)
@@ -522,27 +522,27 @@ std::size_t region::get_num_point() const {
     return num_anchors;
 }
 
-anchor& region::modify_point(point p) {
+anchor& region::modify_anchor(point p) {
     auto& a = anchor_list_[static_cast<int>(p)];
     if (!a) {
         throw gui::exception(
-            "region", "Cannot modify a point that does not exist. Use set_point() first.");
+            "region", "Cannot modify a point that does not exist. Use set_anchor() first.");
     }
 
     return *a;
 }
 
-const anchor& region::get_point(point p) const {
+const anchor& region::get_anchor(point p) const {
     const auto& a = anchor_list_[static_cast<int>(p)];
     if (!a) {
         throw gui::exception(
-            "region", "Cannot get a point that does not exist. Use set_point() first.");
+            "region", "Cannot get an anchor that does not exist. Use set_anchor() first.");
     }
 
     return *a;
 }
 
-const std::array<std::optional<anchor>, 9>& region::get_point_list() const {
+const std::array<std::optional<anchor>, 9>& region::get_anchors() const {
     return anchor_list_;
 }
 

--- a/src/gui_region.cpp
+++ b/src/gui_region.cpp
@@ -769,8 +769,8 @@ const sol::state& region::get_lua_() const {
 }
 
 void region::remove_glue() {
-    get_lua_().globals()[get_name()]               = sol::lua_nil;
-    get_lua_().globals()["_METADATA_"][get_name()] = sol::lua_nil;
+    get_lua_().globals()[get_name()]              = sol::lua_nil;
+    get_lua_().globals()["_METADATA"][get_name()] = sol::lua_nil;
 }
 
 void region::set_manually_inherited(bool manually_inherited) {

--- a/src/gui_region.cpp
+++ b/src/gui_region.cpp
@@ -65,15 +65,15 @@ region::~region() {
                 new_anchor.offset        = a.offset;
 
                 switch (a.parent_point) {
-                case point::top_left: new_anchor.offset += border_list_.top_left(); break;
-                case point::top: new_anchor.offset.y += border_list_.top; break;
-                case point::top_right: new_anchor.offset += border_list_.top_right(); break;
-                case point::right: new_anchor.offset.x += border_list_.right; break;
-                case point::bottom_right: new_anchor.offset += border_list_.bottom_right(); break;
-                case point::bottom: new_anchor.offset.y += border_list_.bottom; break;
-                case point::bottom_left: new_anchor.offset += border_list_.bottom_left(); break;
-                case point::left: new_anchor.offset.x += border_list_.left; break;
-                case point::center: new_anchor.offset += border_list_.center(); break;
+                case point::top_left: new_anchor.offset += borders_.top_left(); break;
+                case point::top: new_anchor.offset.y += borders_.top; break;
+                case point::top_right: new_anchor.offset += borders_.top_right(); break;
+                case point::right: new_anchor.offset.x += borders_.right; break;
+                case point::bottom_right: new_anchor.offset += borders_.bottom_right(); break;
+                case point::bottom: new_anchor.offset.y += borders_.bottom; break;
+                case point::bottom_left: new_anchor.offset += borders_.bottom_left(); break;
+                case point::left: new_anchor.offset.x += borders_.left; break;
+                case point::center: new_anchor.offset += borders_.center(); break;
                 }
 
                 obj->set_point(new_anchor);
@@ -115,10 +115,10 @@ std::string region::serialize(const std::string& tab) const {
     }
     str << tab << "  # Borders :\n";
     str << tab << "  |-###\n";
-    str << tab << "  |   # left  : " << border_list_.left << "\n";
-    str << tab << "  |   # top   : " << border_list_.top << "\n";
-    str << tab << "  |   # right : " << border_list_.right << "\n";
-    str << tab << "  |   # bottom: " << border_list_.bottom << "\n";
+    str << tab << "  |   # left  : " << borders_.left << "\n";
+    str << tab << "  |   # top   : " << borders_.top << "\n";
+    str << tab << "  |   # right : " << borders_.right << "\n";
+    str << tab << "  |   # bottom: " << borders_.bottom << "\n";
     str << tab << "  |-###\n";
     str << tab << "  # Alpha      : " << alpha_ << "\n";
     str << tab << "  # Shown      : " << is_shown_ << "\n";
@@ -280,21 +280,21 @@ const vector2f& region::get_dimensions() const {
 }
 
 vector2f region::get_apparent_dimensions() const {
-    return vector2f(border_list_.width(), border_list_.height());
+    return vector2f(borders_.width(), borders_.height());
 }
 
 bool region::is_apparent_width_defined() const {
-    return dimensions_.x > 0.0f || (defined_border_list_.left && defined_border_list_.right);
+    return dimensions_.x > 0.0f || (defined_borders_.left && defined_borders_.right);
 }
 
 bool region::is_apparent_height_defined() const {
-    return dimensions_.y > 0.0f || (defined_border_list_.top && defined_border_list_.bottom);
+    return dimensions_.y > 0.0f || (defined_borders_.top && defined_borders_.bottom);
 }
 
 bool region::is_in_region(const vector2f& position) const {
     return (
-        (border_list_.left <= position.x && position.x <= border_list_.right - 1) &&
-        (border_list_.top <= position.y && position.y <= border_list_.bottom - 1));
+        (borders_.left <= position.x && position.x <= borders_.right - 1) &&
+        (borders_.top <= position.y && position.y <= borders_.bottom - 1));
 }
 
 void region::set_name_(const std::string& name) {
@@ -348,27 +348,27 @@ void region::destroy() {
 }
 
 vector2f region::get_center() const {
-    return border_list_.center();
+    return borders_.center();
 }
 
 float region::get_left() const {
-    return border_list_.left;
+    return borders_.left;
 }
 
 float region::get_right() const {
-    return border_list_.right;
+    return borders_.right;
 }
 
 float region::get_top() const {
-    return border_list_.top;
+    return borders_.top;
 }
 
 float region::get_bottom() const {
-    return border_list_.bottom;
+    return borders_.bottom;
 }
 
 const bounds2f& region::get_borders() const {
-    return border_list_;
+    return borders_;
 }
 
 void region::clear_all_points() {
@@ -381,7 +381,7 @@ void region::clear_all_points() {
     }
 
     if (had_anchors) {
-        defined_border_list_ = bounds2<bool>(false, false, false, false);
+        defined_borders_ = bounds2<bool>(false, false, false, false);
 
         if (!is_virtual_) {
             update_anchors_();
@@ -406,7 +406,7 @@ void region::set_all_points(const std::string& obj_name) {
     anchor_list_[static_cast<int>(point::bottom_right)].emplace(
         *this, anchor_data(point::bottom_right, obj_name));
 
-    defined_border_list_ = bounds2<bool>(true, true, true, true);
+    defined_borders_ = bounds2<bool>(true, true, true, true);
 
     if (!is_virtual_) {
         update_anchors_();
@@ -430,25 +430,25 @@ void region::set_point(const anchor_data& a) {
 
     switch (a.object_point) {
     case point::top_left:
-        defined_border_list_.top  = true;
-        defined_border_list_.left = true;
+        defined_borders_.top  = true;
+        defined_borders_.left = true;
         break;
-    case point::top: defined_border_list_.top = true; break;
+    case point::top: defined_borders_.top = true; break;
     case point::top_right:
-        defined_border_list_.top   = true;
-        defined_border_list_.right = true;
+        defined_borders_.top   = true;
+        defined_borders_.right = true;
         break;
-    case point::right: defined_border_list_.right = true; break;
+    case point::right: defined_borders_.right = true; break;
     case point::bottom_right:
-        defined_border_list_.bottom = true;
-        defined_border_list_.right  = true;
+        defined_borders_.bottom = true;
+        defined_borders_.right  = true;
         break;
-    case point::bottom: defined_border_list_.bottom = true; break;
+    case point::bottom: defined_borders_.bottom = true; break;
     case point::bottom_left:
-        defined_border_list_.bottom = true;
-        defined_border_list_.left   = true;
+        defined_borders_.bottom = true;
+        defined_borders_.left   = true;
         break;
-    case point::left: defined_border_list_.left = true; break;
+    case point::left: defined_borders_.left = true; break;
     default: break;
     }
 
@@ -632,7 +632,7 @@ void region::update_borders_() {
     DEBUG_LOG("  Update anchors for " + lua_name_);
 
     const bool old_is_ready    = is_ready_;
-    const auto old_border_list = border_list_;
+    const auto old_border_list = borders_;
 
     is_ready_ = true;
 
@@ -671,27 +671,27 @@ void region::update_borders_() {
                 bottom = top + 1;
             }
 
-            border_list_ = bounds2f(left, right, top, bottom);
+            borders_ = bounds2f(left, right, top, bottom);
         } else {
-            border_list_ = bounds2f::zero;
+            borders_ = bounds2f::zero;
         }
     } else {
-        border_list_ = bounds2f(0.0, 0.0, dimensions_.x, dimensions_.y);
-        is_ready_    = false;
+        borders_  = bounds2f(0.0, 0.0, dimensions_.x, dimensions_.y);
+        is_ready_ = false;
     }
 
     DEBUG_LOG("  Final borders");
-    border_list_.left   = round_to_pixel(border_list_.left);
-    border_list_.right  = round_to_pixel(border_list_.right);
-    border_list_.top    = round_to_pixel(border_list_.top);
-    border_list_.bottom = round_to_pixel(border_list_.bottom);
+    borders_.left   = round_to_pixel(borders_.left);
+    borders_.right  = round_to_pixel(borders_.right);
+    borders_.top    = round_to_pixel(borders_.top);
+    borders_.bottom = round_to_pixel(borders_.bottom);
 
-    DEBUG_LOG("    left=" + utils::to_string(border_list_.left));
-    DEBUG_LOG("    right=" + utils::to_string(border_list_.right));
-    DEBUG_LOG("    top=" + utils::to_string(border_list_.top));
-    DEBUG_LOG("    bottom=" + utils::to_string(border_list_.bottom));
+    DEBUG_LOG("    left=" + utils::to_string(borders_.left));
+    DEBUG_LOG("    right=" + utils::to_string(borders_.right));
+    DEBUG_LOG("    top=" + utils::to_string(borders_.top));
+    DEBUG_LOG("    bottom=" + utils::to_string(borders_.bottom));
 
-    if (border_list_ != old_border_list || is_ready_ != old_is_ready) {
+    if (borders_ != old_border_list || is_ready_ != old_is_ready) {
         DEBUG_LOG("  Fire redraw");
         notify_renderer_need_redraw();
     }
@@ -741,11 +741,11 @@ void region::notify_borders_need_update() {
         return;
 
     const bool old_ready       = is_ready_;
-    const auto old_border_list = border_list_;
+    const auto old_border_list = borders_;
 
     update_borders_();
 
-    if (border_list_ != old_border_list || is_ready_ != old_ready) {
+    if (borders_ != old_border_list || is_ready_ != old_ready) {
         for (const auto& object : anchored_object_list_)
             object->notify_borders_need_update();
     }

--- a/src/gui_region.cpp
+++ b/src/gui_region.cpp
@@ -97,7 +97,7 @@ std::string region::serialize(const std::string& tab) const {
         << std::string(is_ready_ ? "ready" : "not ready")
         << std::string(is_manually_inherited_ ? ", manually inherited" : "") << ")\n";
     str << tab << "  # Raw name   : " << raw_name_ << "\n";
-    str << tab << "  # Type       : " << type_.back() << "\n";
+    str << tab << "  # Type       : " << get_region_type() << "\n";
     if (parent_)
         str << tab << "  # Parent     : " << parent_->get_name() << "\n";
     else
@@ -147,15 +147,11 @@ const std::string& region::get_raw_name() const {
     return raw_name_;
 }
 
-const std::string& region::get_object_type() const {
+const std::string& region::get_region_type() const {
     return type_.back();
 }
 
-const std::vector<std::string>& region::get_object_type_list() const {
-    return type_;
-}
-
-bool region::is_object_type(const std::string& type_name) const {
+bool region::is_region_type(const std::string& type_name) const {
     return utils::find(type_, type_name) != type_.end();
 }
 
@@ -299,20 +295,20 @@ void region::set_name_(const std::string& name) {
             if (parent_)
                 utils::replace(name_, "$parent", parent_->get_name());
             else {
-                gui::out << gui::warning << "gui::" << type_.back() << ": \"" << name_
+                gui::out << gui::warning << "gui::" << get_region_type() << ": \"" << name_
                          << "\" has no parent" << std::endl;
                 utils::replace(name_, "$parent", "");
             }
         }
     } else {
-        gui::out << gui::warning << "gui::" << type_.back() << ": "
+        gui::out << gui::warning << "gui::" << get_region_type() << ": "
                  << "set_name() can only be called once." << std::endl;
     }
 }
 
 void region::set_parent_(utils::observer_ptr<frame> parent) {
     if (parent == observer_from_this()) {
-        gui::out << gui::error << "gui::" << type_.back() << ": Cannot call set_parent(this)."
+        gui::out << gui::error << "gui::" << get_region_type() << ": Cannot call set_parent(this)."
                  << std::endl;
         return;
     }
@@ -385,8 +381,8 @@ void region::clear_all_points() {
 
 void region::set_all_points(const std::string& obj_name) {
     if (obj_name == name_) {
-        gui::out << gui::error << "gui::" << type_.back() << ": Cannot call set_all_points(this)."
-                 << std::endl;
+        gui::out << gui::error << "gui::" << get_region_type()
+                 << ": Cannot call set_all_points(this)." << std::endl;
         return;
     }
 
@@ -409,8 +405,8 @@ void region::set_all_points(const std::string& obj_name) {
 
 void region::set_all_points(const utils::observer_ptr<region>& obj) {
     if (obj == observer_from_this()) {
-        gui::out << gui::error << "gui::" << type_.back() << ": Cannot call set_all_points(this)."
-                 << std::endl;
+        gui::out << gui::error << "gui::" << get_region_type()
+                 << ": Cannot call set_all_points(this)." << std::endl;
         return;
     }
 
@@ -701,7 +697,8 @@ void region::update_anchors_() {
         utils::observer_ptr<region> obj = a->get_parent();
         if (obj) {
             if (obj->depends_on(*this)) {
-                gui::out << gui::error << "gui::" << type_.back() << ": Cyclic anchor dependency ! "
+                gui::out << gui::error << "gui::" << get_region_type()
+                         << ": Cyclic anchor dependency ! "
                          << "\"" << name_ << "\" and \"" << obj->get_name()
                          << "\" depend on eachothers (directly or indirectly). \""
                          << utils::to_string(a->object_point) << "\" anchor removed." << std::endl;
@@ -814,7 +811,7 @@ std::string region::parse_file_name(const std::string& file_name) const {
 
 void region::set_addon(const addon* a) {
     if (addon_) {
-        gui::out << gui::warning << "gui::" << type_.back()
+        gui::out << gui::warning << "gui::" << get_region_type()
                  << ": set_addon() can only be called once." << std::endl;
         return;
     }

--- a/src/gui_region_glues.cpp
+++ b/src/gui_region_glues.cpp
@@ -174,9 +174,9 @@ void region::register_on_lua(sol::state& lua) {
      */
     type.set_function("set_alpha", member_function<&region::set_alpha>());
 
-    /** @function clear_all_points
+    /** @function clear_all_anchors
      */
-    type.set_function("clear_all_points", member_function<&region::clear_all_points>());
+    type.set_function("clear_all_anchors", member_function<&region::clear_all_anchors>());
 
     /** @function get_bottom
      */
@@ -198,9 +198,9 @@ void region::register_on_lua(sol::state& lua) {
      */
     type.set_function("get_left", member_function<&region::get_left>());
 
-    /** @function get_num_point
+    /** @function get_anchor_count
      */
-    type.set_function("get_num_point", member_function<&region::get_num_point>());
+    type.set_function("get_anchor_count", member_function<&region::get_anchor_count>());
 
     /** @function get_parent
      */
@@ -211,9 +211,9 @@ void region::register_on_lua(sol::state& lua) {
         return parent;
     });
 
-    /** @function get_point
+    /** @function get_anchor
      */
-    type.set_function("get_point", [](const region& self, sol::optional<std::size_t> p) {
+    type.set_function("get_anchor", [](const region& self, sol::optional<std::size_t> p) {
         point point_value = point::top_left;
         if (p.has_value()) {
             if (p.value() > static_cast<std::size_t>(point::center))
@@ -222,7 +222,7 @@ void region::register_on_lua(sol::state& lua) {
             point_value = static_cast<point>(p.value());
         }
 
-        const anchor& a = self.get_point(point_value);
+        const anchor& a = self.get_anchor(point_value);
 
         return std::make_tuple(
             utils::to_string(a.object_point), a.get_parent(), utils::to_string(a.parent_point),
@@ -289,13 +289,13 @@ void region::register_on_lua(sol::state& lua) {
         }
     });
 
-    /** @function set_point
+    /** @function set_anchor
      */
     type.set_function(
-        "set_point", [](region& self, const std::string& point_name,
-                        sol::optional<std::variant<std::string, region*>> parent,
-                        sol::optional<std::string> relative_point, sol::optional<float> x_offset,
-                        sol::optional<float> y_offset) {
+        "set_anchor", [](region& self, const std::string& point_name,
+                         sol::optional<std::variant<std::string, region*>> parent,
+                         sol::optional<std::string> relative_point, sol::optional<float> x_offset,
+                         sol::optional<float> y_offset) {
             // point
             point p = utils::from_string<point>(point_name).value();
 
@@ -321,7 +321,7 @@ void region::register_on_lua(sol::state& lua) {
             float abs_x = x_offset.value_or(0.0f);
             float abs_y = y_offset.value_or(0.0f);
 
-            self.set_point(
+            self.set_anchor(
                 p, parent_obj ? parent_obj->get_name() : "", parent_point, vector2f(abs_x, abs_y));
         });
 
@@ -357,7 +357,7 @@ void region::register_on_lua(sol::state& lua) {
             float rel_x = x_offset.value_or(0.0f);
             float rel_y = y_offset.value_or(0.0f);
 
-            self.set_point(
+            self.set_anchor(
                 p, parent_obj ? parent_obj->get_name() : "", parent_point, vector2f(rel_x, rel_y),
                 anchor_type::rel);
         });

--- a/src/gui_region_glues.cpp
+++ b/src/gui_region_glues.cpp
@@ -154,16 +154,16 @@ void region::register_on_lua(sol::state& lua) {
      */
     type.set_function("get_name", member_function<&region::get_name>());
 
-    /** @function get_object_type
+    /** @function get_region_type
      */
-    type.set_function("get_object_type", member_function<&region::get_object_type>());
+    type.set_function("get_region_type", member_function<&region::get_region_type>());
 
-    /** @function is_object_type
+    /** @function is_region_type
      */
     type.set_function(
-        "is_object_type",
+        "is_region_type",
         member_function< // select the right overload for Lua
-            static_cast<bool (region::*)(const std::string&) const>(&region::is_object_type)>());
+            static_cast<bool (region::*)(const std::string&) const>(&region::is_region_type)>());
 
     /** @function set_alpha
      */
@@ -269,14 +269,14 @@ void region::register_on_lua(sol::state& lua) {
         utils::observer_ptr<frame> parent_obj = get_object<frame>(self.get_manager(), parent);
 
         if (parent_obj) {
-            if (self.is_object_type<frame>())
+            if (self.is_region_type<frame>())
                 parent_obj->add_child(
                     utils::static_pointer_cast<frame>(self.release_from_parent()));
             else
                 parent_obj->add_region(
                     utils::static_pointer_cast<layered_region>(self.release_from_parent()));
         } else {
-            if (self.is_object_type<frame>()) {
+            if (self.is_region_type<frame>()) {
                 self.get_manager().get_root().add_root_frame(
                     utils::static_pointer_cast<frame>(self.release_from_parent()));
             } else

--- a/src/gui_region_glues.cpp
+++ b/src/gui_region_glues.cpp
@@ -254,12 +254,12 @@ void region::register_on_lua(sol::state& lua) {
      */
     type.set_function("is_visible", member_function<&region::is_visible>());
 
-    /** @function set_all_points
+    /** @function set_all_anchors
      */
     type.set_function(
-        "set_all_points",
+        "set_all_anchors",
         [](region& self, sol::optional<std::variant<std::string, region*>> target) {
-            self.set_all_points(
+            self.set_all_anchors(
                 target.has_value() ? get_object<region>(self.get_manager(), target.value())
                                    : nullptr);
         });

--- a/src/gui_region_glues.cpp
+++ b/src/gui_region_glues.cpp
@@ -126,7 +126,7 @@ namespace lxgui::gui {
 
 void region::set_lua_member_(std::string key, sol::stack_object value) {
     auto& lua  = get_lua_();
-    auto  self = lua.globals()["_METADATA_"][get_name()];
+    auto  self = lua.globals()["_METADATA"][get_name()];
 
     if (!self.valid()) {
         self = sol::table(lua.lua_state(), sol::create);
@@ -137,7 +137,7 @@ void region::set_lua_member_(std::string key, sol::stack_object value) {
 
 sol::object region::get_lua_member_(const std::string& key) const {
     auto& lua  = get_lua_();
-    auto  self = lua.globals()["_METADATA_"][get_name()];
+    auto  self = lua.globals()["_METADATA"][get_name()];
 
     if (self.valid()) {
         return self[key];

--- a/src/gui_region_glues.cpp
+++ b/src/gui_region_glues.cpp
@@ -125,20 +125,25 @@
 namespace lxgui::gui {
 
 void region::set_lua_member_(std::string key, sol::stack_object value) {
-    auto iter = lua_members_.find(key);
-    if (iter == lua_members_.cend()) {
-        lua_members_.insert(iter, {std::move(key), value});
-    } else {
-        iter->second = sol::object(value);
+    auto& lua  = get_lua_();
+    auto  self = lua.globals()["_METADATA_"][get_name()];
+
+    if (!self.valid()) {
+        self = sol::table(lua.lua_state(), sol::create);
     }
+
+    self[key] = value;
 }
 
 sol::object region::get_lua_member_(const std::string& key) const {
-    auto iter = lua_members_.find(key);
-    if (iter == lua_members_.cend())
-        return sol::lua_nil;
+    auto& lua  = get_lua_();
+    auto  self = lua.globals()["_METADATA_"][get_name()];
 
-    return iter->second;
+    if (self.valid()) {
+        return self[key];
+    } else {
+        return sol::lua_nil;
+    }
 }
 
 void region::register_on_lua(sol::state& lua) {

--- a/src/gui_region_glues.cpp
+++ b/src/gui_region_glues.cpp
@@ -202,7 +202,7 @@ void region::register_on_lua(sol::state& lua) {
     type.set_function("get_parent", [](region& self) {
         sol::object parent;
         if (auto* self_parent = self.get_parent().get())
-            parent = self.get_manager().get_lua()[self_parent->get_lua_name()];
+            parent = self.get_manager().get_lua()[self_parent->get_name()];
         return parent;
     });
 

--- a/src/gui_region_parser.cpp
+++ b/src/gui_region_parser.cpp
@@ -120,7 +120,7 @@ void region::parse_anchor_node_(const layout_node& node) {
                     dimensions.second.x.value_or(0.0f), dimensions.second.y.value_or(0.0f));
             }
 
-            set_point(a);
+            set_anchor(a);
         }
     }
 }

--- a/src/gui_region_parser.cpp
+++ b/src/gui_region_parser.cpp
@@ -132,8 +132,8 @@ void region::parse_layout(const layout_node& node) {
 }
 
 void region::parse_attributes_(const layout_node& node) {
-    if (node.get_attribute_value_or<bool>("setAllPoints", false))
-        set_all_points("$parent");
+    if (node.get_attribute_value_or<bool>("setAllAnchors", false))
+        set_all_anchors("$parent");
 }
 
 } // namespace lxgui::gui

--- a/src/gui_renderer.cpp
+++ b/src/gui_renderer.cpp
@@ -9,8 +9,6 @@
 namespace lxgui::gui {
 
 void renderer::begin(std::shared_ptr<render_target> target) {
-    batch_count_ = 0;
-
     if (is_quad_batching_enabled()) {
         current_material_ = nullptr;
 
@@ -39,10 +37,18 @@ void renderer::begin(std::shared_ptr<render_target> target) {
 void renderer::end() {
     if (is_quad_batching_enabled()) {
         flush_quad_batch();
-        last_frame_batch_count_ = batch_count_;
     }
 
     end_();
+}
+
+void renderer::reset_batch_count() {
+    last_frame_batch_count_ = batch_count_;
+    batch_count_            = 0;
+}
+
+std::size_t renderer::get_batch_count() const {
+    return last_frame_batch_count_;
 }
 
 void renderer::set_view(const matrix4f& view_matrix) {

--- a/src/gui_renderer.cpp
+++ b/src/gui_renderer.cpp
@@ -42,13 +42,19 @@ void renderer::end() {
     end_();
 }
 
-void renderer::reset_batch_count() {
-    last_frame_batch_count_ = batch_count_;
-    batch_count_            = 0;
+void renderer::reset_counters() {
+    last_frame_batch_count_  = batch_count_;
+    last_frame_vertex_count_ = vertex_count_;
+    batch_count_             = 0;
+    vertex_count_            = 0;
 }
 
 std::size_t renderer::get_batch_count() const {
     return last_frame_batch_count_;
+}
+
+std::size_t renderer::get_vertex_count() const {
+    return last_frame_vertex_count_;
 }
 
 void renderer::set_view(const matrix4f& view_matrix) {
@@ -87,6 +93,7 @@ void renderer::render_quads(
 
     if (!is_quad_batching_enabled()) {
         // Render immediately
+        vertex_count_ += quad_list.size() * 4;
         render_quads_(mat, quad_list);
         return;
     }
@@ -130,6 +137,8 @@ void renderer::flush_quad_batch() {
     if (cache.data.empty())
         return;
 
+    vertex_count_ += cache.data.size() * 4;
+
     if (cache.cache) {
         cache.cache->update(cache.data[0].data(), cache.data.size() * 4);
         render_cache_(current_material_, *cache.cache, matrix4f::identity);
@@ -152,6 +161,8 @@ void renderer::render_cache(
     if (is_quad_batching_enabled()) {
         flush_quad_batch();
     }
+
+    vertex_count_ += cache.get_num_vertex() * 4;
 
     render_cache_(mat, cache, model_transform);
 }

--- a/src/gui_renderer.cpp
+++ b/src/gui_renderer.cpp
@@ -162,7 +162,7 @@ void renderer::render_cache(
         flush_quad_batch();
     }
 
-    vertex_count_ += cache.get_num_vertex() * 4;
+    vertex_count_ += cache.get_vertex_count() * 4;
 
     render_cache_(mat, cache, model_transform);
 }
@@ -259,11 +259,11 @@ void renderer::set_texture_atlas_page_size(std::size_t page_size) {
     texture_atlas_page_size_ = page_size;
 }
 
-std::size_t renderer::get_num_texture_atlas_pages() const {
+std::size_t renderer::get_texture_atlas_page_count() const {
     std::size_t count = 0;
 
     for (const auto& page : atlas_list_) {
-        count += page.second->get_num_pages();
+        count += page.second->get_page_count();
     }
 
     return count;

--- a/src/gui_root.cpp
+++ b/src/gui_root.cpp
@@ -279,10 +279,10 @@ void root::start_moving(
         } else {
             const bounds2f borders = moved_object_->get_borders();
 
-            moved_object_->clear_all_points();
-            moved_object_->set_point(point::top_left, "", borders.top_left());
+            moved_object_->clear_all_anchors();
+            moved_object_->set_anchor(point::top_left, "", borders.top_left());
 
-            moved_anchor_ = &moved_object_->modify_point(point::top_left);
+            moved_anchor_ = &moved_object_->modify_anchor(point::top_left);
 
             movement_start_position_ = borders.top_left();
         }
@@ -346,8 +346,8 @@ void root::start_sizing(utils::observer_ptr<region> obj, point p) {
             return;
         }
 
-        sized_object_->clear_all_points();
-        sized_object_->set_point(opposite_point, "", point::top_left, offset);
+        sized_object_->clear_all_anchors();
+        sized_object_->set_anchor(opposite_point, "", point::top_left, offset);
 
         resize_start_ = sized_object_->get_apparent_dimensions();
 

--- a/src/gui_scroll_frame.cpp
+++ b/src/gui_scroll_frame.cpp
@@ -66,7 +66,7 @@ void scroll_frame::copy_from(const region& obj) {
         utils::observer_ptr<frame> scroll_child = create_child(std::move(attr));
 
         if (scroll_child) {
-            scroll_child->set_special();
+            scroll_child->set_manually_inherited(true);
             scroll_child->notify_loaded();
             this->set_scroll_child(remove_child(scroll_child));
         }
@@ -86,7 +86,7 @@ void scroll_frame::set_scroll_child(utils::owner_ptr<frame> obj) {
         if (!scroll_texture)
             return;
 
-        scroll_texture->set_special();
+        scroll_texture->set_manually_inherited(true);
         scroll_texture->set_all_points(observer_from(this));
 
         if (scroll_render_target_)
@@ -103,7 +103,7 @@ void scroll_frame::set_scroll_child(utils::owner_ptr<frame> obj) {
     if (scroll_child_) {
         add_child(std::move(obj));
 
-        scroll_child_->set_special();
+        scroll_child_->set_manually_inherited(true);
         if (!is_virtual())
             scroll_child_->set_frame_renderer(observer_from(this));
 

--- a/src/gui_scroll_frame.cpp
+++ b/src/gui_scroll_frame.cpp
@@ -107,9 +107,9 @@ void scroll_frame::set_scroll_child(utils::owner_ptr<frame> obj) {
         if (!is_virtual())
             scroll_child_->set_frame_renderer(observer_from(this));
 
-        scroll_child_->clear_all_points();
+        scroll_child_->clear_all_anchors();
         if (!is_virtual())
-            scroll_child_->set_point(point::top_left, get_name(), -scroll_);
+            scroll_child_->set_anchor(point::top_left, get_name(), -scroll_);
 
         update_scroll_range_();
     }
@@ -128,7 +128,7 @@ void scroll_frame::set_horizontal_scroll(float horizontal_scroll) {
     if (!checker.is_alive())
         return;
 
-    scroll_child_->modify_point(point::top_left).offset = -scroll_;
+    scroll_child_->modify_anchor(point::top_left).offset = -scroll_;
     scroll_child_->notify_borders_need_update();
 
     redraw_scroll_render_target_flag_ = true;
@@ -153,7 +153,7 @@ void scroll_frame::set_vertical_scroll(float vertical_scroll) {
     if (!checker.is_alive())
         return;
 
-    scroll_child_->modify_point(point::top_left).offset = -scroll_;
+    scroll_child_->modify_anchor(point::top_left).offset = -scroll_;
     scroll_child_->notify_borders_need_update();
 
     redraw_scroll_render_target_flag_ = true;

--- a/src/gui_scroll_frame.cpp
+++ b/src/gui_scroll_frame.cpp
@@ -59,7 +59,7 @@ void scroll_frame::copy_from(const region& obj) {
 
     if (const frame* other_child = scroll_obj->get_scroll_child().get()) {
         frame_core_attributes attr;
-        attr.object_type = other_child->get_object_type();
+        attr.object_type = other_child->get_region_type();
         attr.name        = other_child->get_raw_name();
         attr.inheritance = {scroll_obj->get_scroll_child()};
 

--- a/src/gui_scroll_frame.cpp
+++ b/src/gui_scroll_frame.cpp
@@ -292,4 +292,8 @@ vector2f scroll_frame::get_target_dimensions() const {
     return get_apparent_dimensions();
 }
 
+const std::vector<std::string>& scroll_frame::get_type_list_() const {
+    return get_type_list_impl_<scroll_frame>();
+}
+
 } // namespace lxgui::gui

--- a/src/gui_scroll_frame.cpp
+++ b/src/gui_scroll_frame.cpp
@@ -87,7 +87,7 @@ void scroll_frame::set_scroll_child(utils::owner_ptr<frame> obj) {
             return;
 
         scroll_texture->set_manually_inherited(true);
-        scroll_texture->set_all_points(observer_from(this));
+        scroll_texture->set_all_anchors(observer_from(this));
 
         if (scroll_render_target_)
             scroll_texture->set_texture(scroll_render_target_);

--- a/src/gui_scroll_frame_parser.cpp
+++ b/src/gui_scroll_frame_parser.cpp
@@ -12,13 +12,13 @@ void scroll_frame::parse_all_nodes_before_children_(const layout_node& node) {
 
 void scroll_frame::parse_scroll_child_node_(const layout_node& node) {
     if (const layout_node* scroll_child_node = node.try_get_child("ScrollChild")) {
-        if (scroll_child_node->get_children_count() == 0) {
+        if (scroll_child_node->get_child_count() == 0) {
             gui::out << gui::warning << scroll_child_node->get_location()
                      << ": ScrollChild node needs a child node." << std::endl;
             return;
         }
 
-        if (scroll_child_node->get_children_count() > 1) {
+        if (scroll_child_node->get_child_count() > 1) {
             gui::out << gui::warning << scroll_child_node->get_location()
                      << ": ScrollChild node needs only one child node; other nodes will be ignored."
                      << std::endl;

--- a/src/gui_slider.cpp
+++ b/src/gui_slider.cpp
@@ -106,7 +106,7 @@ void slider::copy_from(const region& obj) {
 
     if (const texture* thumb = slider_obj->get_thumb_texture().get()) {
         region_core_attributes attr;
-        attr.name        = thumb->get_name();
+        attr.name        = thumb->get_raw_name();
         attr.inheritance = {slider_obj->get_thumb_texture()};
 
         auto tex = this->create_layered_region<texture>(thumb->get_draw_layer(), std::move(attr));

--- a/src/gui_slider.cpp
+++ b/src/gui_slider.cpp
@@ -55,7 +55,7 @@ void slider::fire_script(const std::string& script_name, const event_data& data)
     if (script_name == "OnDragStart") {
         if (thumb_texture_ &&
             thumb_texture_->is_in_region({data.get<float>(2), data.get<float>(3)})) {
-            anchor& a = thumb_texture_->modify_point(point::center);
+            anchor& a = thumb_texture_->modify_anchor(point::center);
 
             get_manager().get_root().start_moving(
                 thumb_texture_, &a,
@@ -133,9 +133,9 @@ void slider::constrain_thumb_() {
 
     if (is_thumb_dragged_) {
         if (orientation_ == orientation::horizontal)
-            value_ = thumb_texture_->get_point(point::center).offset.x / apparent_size.x;
+            value_ = thumb_texture_->get_anchor(point::center).offset.x / apparent_size.x;
         else
-            value_ = thumb_texture_->get_point(point::center).offset.y / apparent_size.y;
+            value_ = thumb_texture_->get_anchor(point::center).offset.y / apparent_size.y;
 
         value_ = value_ * (max_value_ - min_value_) + min_value_;
         value_ = std::clamp(value_, min_value_, max_value_);
@@ -144,7 +144,7 @@ void slider::constrain_thumb_() {
 
     float coef = (value_ - min_value_) / (max_value_ - min_value_);
 
-    anchor& a = thumb_texture_->modify_point(point::center);
+    anchor& a = thumb_texture_->modify_anchor(point::center);
 
     vector2f new_offset;
     if (orientation_ == orientation::horizontal)
@@ -254,8 +254,8 @@ void slider::set_thumb_texture(utils::observer_ptr<texture> tex) {
         return;
 
     thumb_texture_->set_draw_layer(thumb_layer_);
-    thumb_texture_->clear_all_points();
-    thumb_texture_->set_point(
+    thumb_texture_->clear_all_anchors();
+    thumb_texture_->set_anchor(
         point::center, thumb_texture_->get_parent().get() == this ? "$parent" : name_,
         orientation_ == orientation::horizontal ? point::left : point::top);
 
@@ -269,7 +269,7 @@ void slider::set_orientation(orientation orient) {
     orientation_ = orient;
 
     if (thumb_texture_) {
-        thumb_texture_->set_point(
+        thumb_texture_->set_anchor(
             point::center, name_,
             orientation_ == orientation::horizontal ? point::left : point::top);
     }

--- a/src/gui_slider.cpp
+++ b/src/gui_slider.cpp
@@ -347,4 +347,8 @@ void slider::notify_thumb_texture_needs_update_() {
     update_thumb_texture_();
 }
 
+const std::vector<std::string>& slider::get_type_list_() const {
+    return get_type_list_impl_<slider>();
+}
+
 } // namespace lxgui::gui

--- a/src/gui_slider.cpp
+++ b/src/gui_slider.cpp
@@ -112,7 +112,7 @@ void slider::copy_from(const region& obj) {
         auto tex = this->create_layered_region<texture>(thumb->get_draw_layer(), std::move(attr));
 
         if (tex) {
-            tex->set_special();
+            tex->set_manually_inherited(true);
             tex->notify_loaded();
             this->set_thumb_texture(tex);
         }

--- a/src/gui_slider.cpp
+++ b/src/gui_slider.cpp
@@ -77,11 +77,11 @@ void slider::fire_script(const std::string& script_name, const event_data& data)
 
             float value;
             if (orientation_ == orientation::horizontal) {
-                float offset = data.get<float>(2) - border_list_.left;
+                float offset = data.get<float>(2) - borders_.left;
                 value        = offset / apparent_size.x;
                 set_value(value * (max_value_ - min_value_) + min_value_);
             } else {
-                float offset = data.get<float>(3) - border_list_.top;
+                float offset = data.get<float>(3) - borders_.top;
                 value        = offset / apparent_size.y;
                 set_value(value * (max_value_ - min_value_) + min_value_);
             }

--- a/src/gui_slider_parser.cpp
+++ b/src/gui_slider_parser.cpp
@@ -49,7 +49,7 @@ void slider::parse_all_nodes_before_children_(const layout_node& node) {
 
         auto thumb_texture = parse_region_(defaulted, "ARTWORK", "Texture");
         if (thumb_texture) {
-            thumb_texture->set_special();
+            thumb_texture->set_manually_inherited(true);
             set_thumb_texture(utils::static_pointer_cast<texture>(thumb_texture));
         }
 

--- a/src/gui_status_bar.cpp
+++ b/src/gui_status_bar.cpp
@@ -280,4 +280,8 @@ void status_bar::notify_bar_texture_needs_update_() {
     bar_texture_->set_tex_rect(uvs);
 }
 
+const std::vector<std::string>& status_bar::get_type_list_() const {
+    return get_type_list_impl_<status_bar>();
+}
+
 } // namespace lxgui::gui

--- a/src/gui_status_bar.cpp
+++ b/src/gui_status_bar.cpp
@@ -161,14 +161,14 @@ void status_bar::set_bar_texture(utils::observer_ptr<texture> bar_texture) {
         return;
 
     bar_texture_->set_draw_layer(bar_layer_);
-    bar_texture_->clear_all_points();
+    bar_texture_->clear_all_anchors();
 
     std::string parent = bar_texture_->get_parent().get() == this ? "$parent" : name_;
 
     if (is_reversed_) {
-        bar_texture_->set_point(point::top_right, parent);
+        bar_texture_->set_anchor(point::top_right, parent);
     } else {
-        bar_texture_->set_point(point::bottom_left, parent);
+        bar_texture_->set_anchor(point::bottom_left, parent);
     }
 
     initial_text_coords_ = select_uvs(bar_texture_->get_tex_coord());
@@ -198,9 +198,9 @@ void status_bar::set_reversed(bool reversed) {
 
     if (bar_texture_) {
         if (is_reversed_) {
-            bar_texture_->set_point(point::top_right);
+            bar_texture_->set_anchor(point::top_right);
         } else {
-            bar_texture_->set_point(point::bottom_left);
+            bar_texture_->set_anchor(point::bottom_left);
         }
 
         if (!is_virtual_) {

--- a/src/gui_status_bar.cpp
+++ b/src/gui_status_bar.cpp
@@ -55,7 +55,7 @@ void status_bar::copy_from(const region& obj) {
 
     if (const texture* bar = bar_obj->get_bar_texture().get()) {
         region_core_attributes attr;
-        attr.name        = bar->get_name();
+        attr.name        = bar->get_raw_name();
         attr.inheritance = {bar_obj->get_bar_texture()};
 
         auto bar_texture =

--- a/src/gui_status_bar.cpp
+++ b/src/gui_status_bar.cpp
@@ -62,7 +62,7 @@ void status_bar::copy_from(const region& obj) {
             this->create_layered_region<texture>(bar->get_draw_layer(), std::move(attr));
 
         if (bar_texture) {
-            bar_texture->set_special();
+            bar_texture->set_manually_inherited(true);
             bar_texture->notify_loaded();
             this->set_bar_texture(bar_texture);
         }
@@ -245,7 +245,7 @@ void status_bar::create_bar_texture_() {
     if (!bar_texture)
         return;
 
-    bar_texture->set_special();
+    bar_texture->set_manually_inherited(true);
     bar_texture->notify_loaded();
     set_bar_texture(bar_texture);
 }

--- a/src/gui_status_bar_parser.cpp
+++ b/src/gui_status_bar_parser.cpp
@@ -59,7 +59,7 @@ void status_bar::parse_all_nodes_before_children_(const layout_node& node) {
 
         auto bar_texture = parse_region_(defaulted, "ARTWORK", "Texture");
         if (bar_texture) {
-            bar_texture->set_special();
+            bar_texture->set_manually_inherited(true);
             set_bar_texture(utils::static_pointer_cast<texture>(bar_texture));
         }
 

--- a/src/gui_text.cpp
+++ b/src/gui_text.cpp
@@ -280,7 +280,8 @@ float get_string_width(const text& txt, const std::vector<item>& content) {
 /** \endcond
  */
 
-text::text(renderer& rdr, std::shared_ptr<font> fnt, std::shared_ptr<font> outline_font) :
+text::text(
+    renderer& rdr, std::shared_ptr<const font> fnt, std::shared_ptr<const font> outline_font) :
     renderer_(rdr), font_(std::move(fnt)), outline_font_(std::move(outline_font)) {
 
     if (!font_)
@@ -968,7 +969,7 @@ void text::update_() const {
     update_cache_flag_ = false;
 }
 
-std::array<vertex, 4> text::create_letter_quad_(gui::font& font, char32_t c) const {
+std::array<vertex, 4> text::create_letter_quad_(const gui::font& font, char32_t c) const {
     bounds2f quad = font.get_character_bounds(c) * scaling_factor_;
 
     std::array<vertex, 4> vertex_list;

--- a/src/gui_text.cpp
+++ b/src/gui_text.cpp
@@ -408,7 +408,7 @@ float text::get_text_height() const {
     return height;
 }
 
-std::size_t text::get_num_lines() const {
+std::size_t text::get_line_count() const {
     update_();
     return num_lines_;
 }
@@ -1003,7 +1003,7 @@ quad text::create_letter_quad(char32_t c) const {
     return output;
 }
 
-std::size_t text::get_num_letters() const {
+std::size_t text::get_letter_count() const {
     update_();
     return quad_list_.size();
 }

--- a/src/gui_text.cpp
+++ b/src/gui_text.cpp
@@ -99,7 +99,7 @@ parse_string(renderer& renderer, const utils::ustring_view& caption, bool format
                     const auto words = utils::cut(extracted, ":");
                     if (!words.empty()) {
                         texture texture;
-                        texture.mat   = renderer.create_material(std::string{words[0]});
+                        texture.mat = renderer.create_atlas_material("GUI", std::string{words[0]});
                         texture.width = texture.height = std::numeric_limits<float>::quiet_NaN();
 
                         if (words.size() == 2) {

--- a/src/gui_texture.cpp
+++ b/src/gui_texture.cpp
@@ -153,7 +153,7 @@ const std::string& texture::get_texture_file() const {
 
 color texture::get_vertex_color(std::size_t index) const {
     if (index >= 4) {
-        gui::out << gui::error << "gui::" << type_.back() << ": "
+        gui::out << gui::error << "gui::" << get_region_type() << ": "
                  << "Vertex index out of bound (" << index << ")." << std::endl;
         return color::white;
     }
@@ -167,7 +167,7 @@ bool texture::is_desaturated() const {
 
 void texture::set_blend_mode(blend_mode mode) {
     if (mode != blend_mode::blend) {
-        gui::out << gui::warning << "gui::" << type_.back() << ": "
+        gui::out << gui::warning << "gui::" << get_region_type() << ": "
                  << "texture::set_blend_mode other than \"BLEND\" is not yet implemented."
                  << std::endl;
         return;
@@ -201,7 +201,7 @@ void texture::set_desaturated(bool is_desaturated) {
 
     is_desaturated_ = is_desaturated;
     if (is_desaturated) {
-        gui::out << gui::warning << "gui::" << type_.back() << ": "
+        gui::out << gui::warning << "gui::" << get_region_type() << ": "
                  << "Texture de-saturation is not yet implemented." << std::endl;
     }
 
@@ -311,7 +311,7 @@ void texture::set_texture(const std::string& file_name) {
         if (!is_apparent_height_defined())
             set_height(quad_.mat->get_rect().height());
     } else {
-        gui::out << gui::error << "gui::" << type_.back() << ": "
+        gui::out << gui::error << "gui::" << get_region_type() << ": "
                  << "Cannot load file \"" << parsed_file << "\" for \"" << name_
                  << "\". Using white texture instead." << std::endl;
     }
@@ -342,7 +342,7 @@ void texture::set_texture(std::shared_ptr<render_target> target) {
         if (!is_apparent_height_defined())
             set_height(quad_.mat->get_rect().height());
     } else {
-        gui::out << gui::error << "gui::" << type_.back() << ": "
+        gui::out << gui::error << "gui::" << get_region_type() << ": "
                  << "Cannot create a texture from render target. Using white texture instead."
                  << std::endl;
     }
@@ -382,7 +382,7 @@ void texture::set_vertex_color(const color& c, std::size_t index) {
     }
 
     if (index >= 4) {
-        gui::out << gui::error << "gui::" << type_.back() << ": "
+        gui::out << gui::error << "gui::" << get_region_type() << ": "
                  << "Vertex index out of bound (" << index << ")." << std::endl;
         return;
     }

--- a/src/gui_texture.cpp
+++ b/src/gui_texture.cpp
@@ -395,10 +395,10 @@ void texture::set_vertex_color(const color& c, std::size_t index) {
 void texture::update_borders_() {
     base::update_borders_();
 
-    quad_.v[0].pos = border_list_.top_left();
-    quad_.v[1].pos = border_list_.top_right();
-    quad_.v[2].pos = border_list_.bottom_right();
-    quad_.v[3].pos = border_list_.bottom_left();
+    quad_.v[0].pos = borders_.top_left();
+    quad_.v[1].pos = borders_.top_right();
+    quad_.v[2].pos = borders_.bottom_right();
+    quad_.v[3].pos = borders_.bottom_left();
 }
 
 } // namespace lxgui::gui

--- a/src/gui_texture.cpp
+++ b/src/gui_texture.cpp
@@ -401,4 +401,8 @@ void texture::update_borders_() {
     quad_.v[3].pos = borders_.bottom_left();
 }
 
+const std::vector<std::string>& texture::get_type_list_() const {
+    return get_type_list_impl_<texture>();
+}
+
 } // namespace lxgui::gui

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -165,6 +165,9 @@ void main_loop(void* type_erased_data) {
         SDL_GL_MakeCurrent(context.window, context.gl_context);
 #endif
 
+        // Reset batch count (for analytics only, optional)
+        context.manager->get_renderer().reset_batch_count();
+
         // Update the gui
         timing_clock::time_point start = timing_clock::now();
         context.manager->update_ui(context.delta);

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -166,7 +166,7 @@ void main_loop(void* type_erased_data) {
 #endif
 
         // Reset batch count (for analytics only, optional)
-        context.manager->get_renderer().reset_batch_count();
+        context.manager->get_renderer().reset_counters();
 
         // Update the gui
         timing_clock::time_point start = timing_clock::now();

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -468,15 +468,15 @@ int main(int /*argc*/, char* /*argv*/[]) {
         // A "child" frame is owned by another frame.
         utils::observer_ptr<gui::frame> fps_frame;
         fps_frame = manager->get_root().create_root_frame<gui::frame>("FPSCounter");
-        fps_frame->set_point(gui::point::top_left);
-        fps_frame->set_point(
+        fps_frame->set_anchor(gui::point::top_left);
+        fps_frame->set_anchor(
             gui::point::bottom_right, "FontstringTestFrameText", gui::point::top_right);
 
         // Create the FontString
         utils::observer_ptr<gui::font_string> fps_text;
         fps_text =
             fps_frame->create_layered_region<gui::font_string>(gui::layer::artwork, "$parentText");
-        fps_text->set_point(gui::point::bottom_right, gui::vector2f(0, -5));
+        fps_text->set_anchor(gui::point::bottom_right, gui::vector2f(0, -5));
         fps_text->set_font("interface/fonts/main.ttf", 15);
         fps_text->set_alignment_y(gui::alignment_y::bottom);
         fps_text->set_alignment_x(gui::alignment_x::right);


### PR DESCRIPTION
This PR does a bit of refactoring to remove unused or unnecessary members of `region`:
 - rename `region::is_special()` into `region::is_manually_inherited()`
 - rename `region::border_list_` into `region::borders_`
 - rename `region::get_object_type()` into `region::get_region_type`
 - removed `region::id_`
 - removed `region::get_lua_name()` and `region::lua_name_`
 - removed useless overrides of `show`/`hide`/`is_visible`
 - removed `frame::get_frame_type()` and Lua `is_frame_type`
 - removed `region::type_`, using static list instead
 - removed `region::lua_members_`, using Lua instead
 - removed `region::previous_anchor_parent_list_`

Other changes:
 - Fixed `text` not using atlas for icons; will improve performance
 - Fixed `renderer::get_batch_count()` not implemented, and added `renderer::reset_batch_count()`
 - Added `renderer::get_vertex_count()`
 - Added `vertex_cache::get_vertex_count()`
 - Renamed any function of the form `get_num_[...]()` into `get_[...]_count()`
 - Renamed `region::[get/set/modify]_point` to `region::[get/set/modify]_anchor`
 - Renamed `region::clear_all_points` to `region::clear_all_anchors`
 - Renamed `region::set_all_points` to `region::set_all_anchors`