### PR TITLE
Various API clean up, add edit_box locale support, and frame update rate

### DIFF
--- a/bin/interface/scroll_test/addon.lua
+++ b/bin/interface/scroll_test/addon.lua
@@ -64,7 +64,7 @@ function ScrollTest:init_root_folder()
 
         folderButton:set_text(folder)
         local font = folderButton:get_normal_font_object()
-        font:set_word_wrap(false)
+        font:disable_word_wrap()
 
         if rootFolder.lastFolder then
             rootFolder.lastFolder.nextFolder = folderButton
@@ -133,7 +133,7 @@ function ScrollTest:develop_folder(id, toggle)
             folderButton.folderNum = 0
 
             folderButton:set_text(folder)
-            folderButton:get_normal_font_object():set_word_wrap(false)
+            folderButton:get_normal_font_object():disable_word_wrap()
 
             if parentFolder.lastFolder then
                 parentFolder.lastFolder.nextFolder = folderButton
@@ -289,7 +289,7 @@ function ScrollTest:set_folder(id)
             fileButton.file = file
         end
         fileButton:set_text(file)
-        fileButton:get_normal_font_object():set_word_wrap(false)
+        fileButton:get_normal_font_object():disable_word_wrap()
 
         if self.lastFile then
             fileButton:set_anchor("TOP_LEFT", self.lastFile, "BOTTOM_LEFT")

--- a/bin/interface/slider_test/templates.xml
+++ b/bin/interface/slider_test/templates.xml
@@ -1,5 +1,5 @@
 <Ui>
-    <Frame name="FrameTemplate_Dialog" virtual="true" hidden="false" movable="true" enableMouse="true" enableMouseWheel="true" clampedToScreen="true" frameStrata="DIALOG" topLevel="true">
+    <Frame name="FrameTemplate_Dialog" virtual="true" hidden="false" movable="true" enableMouse="true" enableMouseWheel="true" clampedToScreen="true" strata="DIALOG" topLevel="true">
         <Backdrop edgeFile="|dialog_border.png">
             <BackgroundInsets>
                 <AbsInset left="8" right="8" top="8" bottom="8"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -124,6 +124,9 @@ Other changes:
  - gui: renamed [get/set/modify]_point to [get/set/modify]_anchor
  - gui: renamed any function of the form "get_num_[...]()" into "get_[...]_count()"
  - gui: renamed set_all_points/clear_all_points to set_all_anchors/clear_all_anchors
+ - gui: renamed strata to strata_data
+ - gui: renamed frame_level to level
+ - gui: renamed frame_strata to strata
  - gui: removed Frame:on from Lua API (instead, call scripts directly, e.g.: frame:on_update())
  - gui: removed the sprite class
  - gui: removed region::get_base()
@@ -153,7 +156,6 @@ Other changes:
  - gui: all UI objects are now managed with explicit single ownership (unique_ptr)
  - gui: added frame_renderer class interface to clarify the frame class
  - gui: only frames can now be flagged as having a frame_renderer
- - gui: "frame_level" has been renamed to just "level"
  - gui: frame::get_children and frame::get_regions return views rather than containers
  - gui: added gui::down_cast for safer down casting
  - gui: removed clear_links() in favor of using destructors

--- a/changelog.txt
+++ b/changelog.txt
@@ -88,6 +88,18 @@ Other changes:
  - gui: added input::window as an interface to implementation-dependent concepts (clipboard...)
  - gui: added frame::enable_key_capture
  - gui: added OnKeyRepeat frame event
+ - gui: added OnReceiveDrag for frame
+ - gui: added OnCursorChanged for edit_box
+ - gui: added OnUpPressed and OnDownPressed callbacks to edit_box
+ - gui: added set_cursor_position()/get_cursor_position() to edit_box
+ - gui: added clear_history() to edit_box
+ - gui: added clipboard support to edit_box
+ - gui: added automatic un-focus of edit_box when clicking outside of the box
+ - gui: added frame::get_script
+ - gui: added slider::set_orientation(const std::string&)
+ - gui: added status_bar::set_orientation(const std::string&)
+ - gui: added manager::close_ui_now and made close_ui safer
+ - gui: added frame::enable_mouse_click and frame::enable_mouse_move
  - gui: renamed gui::uiobject into gui::region, and merged with previous gui::region
  - gui: renamed gui::manager_impl into gui::renderer
  - gui: renamed gui::gl::manager into gui::gl::renderer
@@ -125,8 +137,8 @@ Other changes:
  - gui: renamed any function of the form "get_num_[...]()" into "get_[...]_count()"
  - gui: renamed set_all_points/clear_all_points to set_all_anchors/clear_all_anchors
  - gui: renamed strata to strata_data
- - gui: renamed frame_level to level
- - gui: renamed frame_strata to strata
+ - gui: renamed frame_level/frameLevel to level
+ - gui: renamed frame_strata/frameStrata to strata
  - gui: removed Frame:on from Lua API (instead, call scripts directly, e.g.: frame:on_update())
  - gui: removed the sprite class
  - gui: removed region::get_base()
@@ -168,22 +180,9 @@ Other changes:
  - gui: renamed OnEditFocusLost to OnFocusLost (now available for FocusFrame too)
  - gui: key and mouse events no longer contain string names of buttons and keys
  - gui: objects inside a scroll_frame can now correctly anchor to other objects
- - gui: added OnReceiveDrag for frame
- - gui: added OnCursorChanged for edit_box
- - gui: added OnUpPressed and OnDownPressed callbacks to edit_box
- - gui: added set_cursor_position()/get_cursor_position() to edit_box
- - gui: added clear_history() to edit_box
- - gui: added clipboard support to edit_box
- - gui: added automatic un-focus of edit_box when clicking outside of the box
- - gui: added frame::get_script
- - gui: added slider::set_orientation(const std::string&)
- - gui: added status_bar::set_orientation(const std::string&)
- - gui: added manager::close_ui_now and made close_ui safer
- - gui: added frame::enable_mouse_click and frame::enable_mouse_move
  - gui: render targets can now have texture filtering other than nearest
  - gui: GUI caching is now disabled by default
  - gui: improved peformance of "update borders" notifications
- - gui: improved peformance of generating new object IDs
  - gui: improved peformance of font outline rendering
  - gui: improved quality and consistency of font rendering in OpenGL back-end
  - gui: fixed rare crash in edit_box

--- a/changelog.txt
+++ b/changelog.txt
@@ -152,6 +152,7 @@ Other changes:
  - gui: renamed enable_key* to set_key*_enabled
  - gui: renamed is_password to is_password_mode_enabled
  - gui: renamed set_password to set_password_mode_enabled
+ - gui: renamed blink_period/blinkPeriod to blink_time/blinkTime
  - gui: removed Frame:on from Lua API (instead, call scripts directly, e.g.: frame:on_update())
  - gui: removed the sprite class
  - gui: removed region::get_base()

--- a/changelog.txt
+++ b/changelog.txt
@@ -100,6 +100,8 @@ Other changes:
  - gui: added status_bar::set_orientation(const std::string&)
  - gui: added manager::close_ui_now and made close_ui safer
  - gui: added frame::enable_mouse_click and frame::enable_mouse_move
+ - gui: added font_string::set_vertex_cache_strategy
+ - gui: added frame::set_update_rate
  - gui: renamed gui::uiobject into gui::region, and merged with previous gui::region
  - gui: renamed gui::manager_impl into gui::renderer
  - gui: renamed gui::gl::manager into gui::gl::renderer

--- a/changelog.txt
+++ b/changelog.txt
@@ -92,7 +92,7 @@ Other changes:
  - gui: added OnCursorChanged for edit_box
  - gui: added OnUpPressed and OnDownPressed callbacks to edit_box
  - gui: added set_cursor_position()/get_cursor_position() to edit_box
- - gui: added clear_history() to edit_box
+ - gui: added clear_history_lines() to edit_box
  - gui: added clipboard support to edit_box
  - gui: added automatic un-focus of edit_box when clicking outside of the box
  - gui: added frame::get_script

--- a/changelog.txt
+++ b/changelog.txt
@@ -139,6 +139,19 @@ Other changes:
  - gui: renamed strata to strata_data
  - gui: renamed frame_level/frameLevel to level
  - gui: renamed frame_strata/frameStrata to strata
+ - gui: renamed can_non_space_wrap to is_non_space_wrap_enabled
+ - gui: renamed set_non_space_wrap to set_non_space_wrap_enabled
+ - gui: renamed has_shadow to is_shadow_enabled
+ - gui: renamed set_shadow to set_shadow_enabled
+ - gui: renamed set_word_wrap to set_word_wrap_enabled
+ - gui: renamed can_word_wrap to is_word_wrap_enabled
+ - gui: renamed can_non_space_wrap to is_non_space_wrap_enabled
+ - gui: renamed set_non_space_wrap to set_word_wrap_enabled
+ - gui: renamed nonspacewrap to nonSpaceWrap
+ - gui: renamed enable_mouse* to set_mouse*_enabled
+ - gui: renamed enable_key* to set_key*_enabled
+ - gui: renamed is_password to is_password_mode_enabled
+ - gui: renamed set_password to set_password_mode_enabled
  - gui: removed Frame:on from Lua API (instead, call scripts directly, e.g.: frame:on_update())
  - gui: removed the sprite class
  - gui: removed region::get_base()

--- a/include/lxgui/gui_button.hpp
+++ b/include/lxgui/gui_button.hpp
@@ -263,6 +263,18 @@ public:
     void set_disabled_text(utils::observer_ptr<font_string> fstr);
 
     /**
+     * \brief Enables or disables this button.
+     * \param enabled 'true' to enable, 'false' to disable
+     */
+    void set_enabled(bool enabled) {
+        if (enabled) {
+            enable();
+        } else {
+            disable();
+        }
+    }
+
+    /**
      * \brief Disables this button.
      * \note A disabled button doesn't receive any input.
      */

--- a/include/lxgui/gui_edit_box.hpp
+++ b/include/lxgui/gui_edit_box.hpp
@@ -221,12 +221,28 @@ public:
     bool is_integer_only() const;
 
     /**
-     * \brief Enables password mode.
+     * \brief Enables or disables password mode.
      * \param enable 'true' to enable password mode
      * \note In password mode, the content of the edit_box is replaced
      * by stars (*).
      */
-    void enable_password_mode(bool enable);
+    void set_password_mode_enabled(bool enable);
+
+    /**
+     * \brief Enables password mode.
+     * \see set_password_mode_enabled
+     */
+    void enable_password_mode() {
+        set_password_mode_enabled(true);
+    }
+
+    /**
+     * \brief Disables password mode.
+     * \see set_password_mode_enabled
+     */
+    void disable_password_mode() {
+        set_password_mode_enabled(false);
+    }
 
     /**
      * \brief Checks if this edit_box is in password mode.

--- a/include/lxgui/gui_edit_box.hpp
+++ b/include/lxgui/gui_edit_box.hpp
@@ -371,7 +371,7 @@ protected:
     void create_highlight_();
     void create_carret_();
 
-    void check_text_();
+    bool check_text_();
     void update_displayed_text_();
     void update_font_string_();
     void update_carret_position_();
@@ -388,7 +388,6 @@ protected:
     utils::ustring           unicode_text_;
     utils::ustring           displayed_text_;
     utils::ustring::iterator iter_carret_pos_;
-    utils::ustring::iterator iter_carret_pos_old_;
 
     std::size_t display_pos_        = 0;
     std::size_t num_letters_        = 0;

--- a/include/lxgui/gui_edit_box.hpp
+++ b/include/lxgui/gui_edit_box.hpp
@@ -73,15 +73,6 @@ public:
     void copy_from(const region& obj) override;
 
     /**
-     * \brief Updates this region's logic.
-     * \param delta Time spent since last update
-     * \note Triggered callbacks could destroy the frame. If you need
-     * to use the frame again after calling this function, use
-     * the helper class alive_checker.
-     */
-    void update(float delta) override;
-
-    /**
      * \brief Calls a script.
      * \param script_name The name of the script
      * \param data Stores scripts arguments
@@ -364,6 +355,8 @@ protected:
     void parse_all_nodes_before_children_(const layout_node& node) override;
     void parse_font_string_node_(const layout_node& node);
     void parse_text_insets_node_(const layout_node& node);
+
+    void update_(float delta) override;
 
     const std::vector<std::string>& get_type_list_() const override;
 

--- a/include/lxgui/gui_edit_box.hpp
+++ b/include/lxgui/gui_edit_box.hpp
@@ -171,16 +171,16 @@ public:
     std::size_t get_letter_count() const;
 
     /**
-     * \brief Sets the carret's blink speed.
-     * \param blink_period The number of seconds to wait between each blink
+     * \brief Sets the carret's blink time.
+     * \param blink_time The number of seconds to wait between each blink
      */
-    void set_blink_period(double blink_period);
+    void set_blink_time(double blink_time);
 
     /**
-     * \brief Returns the carret's blink speed.
-     * \return the carret's blink speed (time in seconds between each blink)
+     * \brief Returns the carret's blink time.
+     * \return the carret's blink time (time in seconds between each blink)
      */
-    double get_blink_period() const;
+    double get_blink_time() const;
 
     /**
      * \brief Makes this edit_box allow numeric characters only.
@@ -406,8 +406,8 @@ protected:
     std::size_t                  selection_end_pos_   = 0u;
     bool                         is_text_selected_    = false;
 
-    utils::observer_ptr<texture> carret_       = nullptr;
-    double                       blink_period_ = 0.5;
+    utils::observer_ptr<texture> carret_     = nullptr;
+    double                       blink_time_ = 0.5;
     utils::periodic_timer        carret_timer_;
 
     std::vector<utils::ustring> history_line_list_;

--- a/include/lxgui/gui_edit_box.hpp
+++ b/include/lxgui/gui_edit_box.hpp
@@ -254,10 +254,10 @@ public:
      * \brief Allows this edit_box to have several lines in it.
      * \param multi_line 'true' to allow several lines in this edit_box
      * \note The behavior of a "multi line" edit_box is very different from
-     * a single line one.<br>
-     * History lines are only available to single line edit_boxes.<br>
-     * Scrolling in a single line edit_box is done horizontally, while
-     * it is only done vertically in a multi line one.
+     * a single line one. History lines are only available to single-line edit_boxes.
+     * Scrolling in a single-line edit_box is done horizontally, while it is only done
+     * vertically in a multi-line one.
+     * \warning Multi-line edit_box is not yet fully implemented!
      */
     void set_multi_line(bool multi_line);
 
@@ -294,7 +294,7 @@ public:
     const std::vector<utils::ustring>& get_history_lines() const;
 
     /// Clears the history line list.
-    void clear_history();
+    void clear_history_lines();
 
     /**
      * \brief Sets whether keyboard arrows move the carret or not.

--- a/include/lxgui/gui_font_string.hpp
+++ b/include/lxgui/gui_font_string.hpp
@@ -9,6 +9,20 @@
 namespace lxgui::gui {
 
 /**
+ * \brief Strategy for using a vertex cache
+ */
+enum class vertex_cache_strategy {
+    /// Never use vertex cache.
+    always_disabled,
+    /// Use vertex cache if renderer supports and allows.
+    prefer_enabled,
+    /// Use vertex cache if renderer supports, even if not allowed.
+    always_enabled,
+    /// Choose automatically to maximize performance on common case.
+    automatic
+};
+
+/**
  * \brief A #layered_region that can draw text on the screen.
  * \details This class holds a string and a reference to a font, which
  * is used to draw the string on the screen. The appearance of
@@ -69,11 +83,11 @@ public:
 
     /**
      * \brief Adds or remove the outline around the text.
-     * \param is_outlined 'true' to enable the outline
+     * \param outlined 'true' to enable the outline
      * \note The thickness of this outline is constant and
      * does not depend on the font's size.
      */
-    void set_outlined(bool is_outlined);
+    void set_outlined(bool outlined);
 
     /**
      * \brief Check if this font_string is outlined.
@@ -277,10 +291,10 @@ public:
 
     /**
      * \brief Enables/disables word wrap.
-     * \param is_word_wrap_enabled 'true' to enable word wrap
+     * \param enabled 'true' to enable word wrap
      * \note Enabled by default.
      */
-    void set_word_wrap_enabled(bool is_word_wrap_enabled);
+    void set_word_wrap_enabled(bool enabled);
 
     /**
      * \brief Enables word wrap.
@@ -304,10 +318,10 @@ public:
 
     /**
      * \brief Sets whether to show an ellipsis "..." if words don't fit in the text box.
-     * \param add_ellipsis 'true' to put "..." at the end of a truncated line
+     * \param enabled 'true' to put "..." at the end of a truncated line
      * \note Disabled by default.
      */
-    void set_word_ellipsis_enabled(bool add_ellipsis);
+    void set_word_ellipsis_enabled(bool enabled);
 
     /**
      * \brief Show an ellipsis "..." if words don't fit in the text box.
@@ -331,10 +345,10 @@ public:
 
     /**
      * \brief Enables color formatting.
-     * \param formatting 'true' to enable color formatting
+     * \param enabled 'true' to enable color formatting
      * \note Enabled by default. See text::set_formatting_enabled().
      */
-    void set_formatting_enabled(bool formatting);
+    void set_formatting_enabled(bool enabled);
 
     /**
      * \brief Enables color formatting.
@@ -357,6 +371,26 @@ public:
      * \return 'true' if color formatting is enabled
      */
     bool is_formatting_enabled() const;
+
+    /**
+     * \brief Selects the strategy for using vertex caches.
+     * \param strategy The new strategy
+     * \note The recommended value is the default, vertex_cache_strategy::automatic.
+     * This will automatically decide whether vertex caches should be used or not, based
+     * on what is expected to give the best performance for the common use case of mostly static
+     * text. If the displayed text changes very frequently, it is best to use the strategy
+     * vertex_cache_strategy::always_disabled. If the displayed text changes rarely and contains a
+     * large number of characters, it is best to use the strategy
+     * vertex_cache_strategy::prefer_enabled, or vertex_cache_strategy::always_enabled if you want
+     * to completely bypass the preferences set in the renderer configuration.
+     */
+    void set_vertex_cache_strategy(vertex_cache_strategy strategy);
+
+    /**
+     * \brief Gets the strategy for using vertex caches.
+     * \return The strategy for using vertex caches
+     */
+    vertex_cache_strategy get_vertex_cache_strategy() const;
 
     /**
      * \brief Sets the rendered text.
@@ -398,6 +432,7 @@ private:
     const std::vector<std::string>& get_type_list_() const override;
 
     void create_text_object_();
+    bool is_vertex_cache_used_() const;
 
     void update_borders_() override;
 
@@ -419,6 +454,8 @@ private:
     bool  ellipsis_enabled_       = true;
     bool  formatting_enabled_     = true;
     color text_color_             = color::white;
+
+    vertex_cache_strategy vertex_cache_strategy_ = vertex_cache_strategy::automatic;
 
     bool     is_shadow_enabled_ = false;
     color    shadow_color_      = color::black;

--- a/include/lxgui/gui_font_string.hpp
+++ b/include/lxgui/gui_font_string.hpp
@@ -192,11 +192,11 @@ public:
     void set_text_color(const color& text_color);
 
     /**
-     * \brief Checks is large text is truncated or wrapped.
+     * \brief Checks if large text is truncated or wrapped.
      * \return 'true' if large text is truncated
-     * \note See set_non_space_wrap for more information.
+     * \note See set_non_space_wrap_enabled for more information.
      */
-    bool can_non_space_wrap() const;
+    bool is_non_space_wrap_enabled() const;
 
     /**
      * \brief Returns the height of the string if no format or wrapping is applied.
@@ -224,47 +224,133 @@ public:
     const utils::ustring& get_text() const;
 
     /**
-     * \brief Sets whether large text is truncated or wrapped.
-     * \param can_non_space_wrap 'true' to truncate the text
-     * \note This applies to large chunks of text with no
-     * spaces. When truncated, "..." is appended at
-     * the line's end. Else, the "word" is cut and
-     * continues on the next line.
+     * \brief Sets whether large text without whitespace is truncated or wrapped.
+     * \param enabled 'true' to wrap, 'false' to truncate
+     * \note This applies to large chunks of text with no spaces. When truncated, "..." is appended
+     * at the line's end. Else, the word is cut and continues on the next line.
      */
-    void set_non_space_wrap(bool can_non_space_wrap);
+    void set_non_space_wrap_enabled(bool enabled);
+
+    /**
+     * \brief Allows large text without whitespace to wrap.
+     * \see set_non_space_wrap_enabled
+     */
+    void enable_non_space_wrap() {
+        set_non_space_wrap_enabled(true);
+    }
+
+    /**
+     * \brief Does not allow large text without whitespace to wrap.
+     * \see set_non_space_wrap_enabled
+     */
+    void disable_non_space_wrap() {
+        set_non_space_wrap_enabled(false);
+    }
 
     /**
      * \brief Checks if this font_string draws a shadow under its text.
      * \return 'true' if this font_string draws a shadow under its text
      */
-    bool has_shadow() const;
+    bool is_shadow_enabled() const;
 
     /**
      * \brief Sets whether this font_string should draw a shadow under its text.
-     * \param has_shadow 'true' to enable shadow
+     * \param enabled 'true' to enable shadow
      */
-    void set_shadow(bool has_shadow);
+    void set_shadow_enabled(bool enabled);
+
+    /**
+     * \brief Makes this font_string draw a shadow under its text.
+     * \see set_shadow_enabled
+     */
+    void enable_shadow() {
+        set_shadow_enabled(true);
+    }
+
+    /**
+     * \brief Makes this font_string draw a shadow under its text.
+     * \see set_shadow_enabled
+     */
+    void disable_shadow() {
+        set_shadow_enabled(false);
+    }
+
+    /**
+     * \brief Enables/disables word wrap.
+     * \param is_word_wrap_enabled 'true' to enable word wrap
+     * \note Enabled by default.
+     */
+    void set_word_wrap_enabled(bool is_word_wrap_enabled);
 
     /**
      * \brief Enables word wrap.
-     * \param can_word_wrap 'true' to enable word wrap
-     * \param add_ellipsis 'true' to put "..." at the end of a truncated line
-     * \note Enabled by default.
      */
-    void set_word_wrap(bool can_word_wrap, bool add_ellipsis);
+    void enable_word_wrap() {
+        set_word_wrap_enabled(true);
+    }
+
+    /**
+     * \brief Disables word wrap.
+     */
+    void disable_word_wrap() {
+        set_word_wrap_enabled(false);
+    }
 
     /**
      * \brief Checks if word wrap is enabled.
      * \return 'true' if word wrap is enabled
      */
-    bool can_word_wrap() const;
+    bool is_word_wrap_enabled() const;
+
+    /**
+     * \brief Sets whether to show an ellipsis "..." if words don't fit in the text box.
+     * \param add_ellipsis 'true' to put "..." at the end of a truncated line
+     * \note Disabled by default.
+     */
+    void set_word_ellipsis_enabled(bool add_ellipsis);
+
+    /**
+     * \brief Show an ellipsis "..." if words don't fit in the text box.
+     */
+    void enable_word_ellipsis() {
+        set_word_ellipsis_enabled(true);
+    }
+
+    /**
+     * \brief Do not show an ellipsis "..." if words don't fit in the text box.
+     */
+    void disable_word_ellipsis() {
+        set_word_ellipsis_enabled(false);
+    }
+
+    /**
+     * \brief Checks if word ellipsis is enabled.
+     * \return 'true' if word ellipsis is enabled
+     */
+    bool is_word_ellipsis_enabled() const;
 
     /**
      * \brief Enables color formatting.
      * \param formatting 'true' to enable color formatting
-     * \note Enabled by default. See text::enable_formatting().
+     * \note Enabled by default. See text::set_formatting_enabled().
      */
-    void enable_formatting(bool formatting);
+    void set_formatting_enabled(bool formatting);
+
+    /**
+     * \brief Enables color formatting.
+     * \see set_formatting_enabled
+     */
+    void enable_formatting() {
+        set_formatting_enabled(true);
+    }
+
+    /**
+     * \brief Disables color formatting.
+     * \see set_formatting_enabled
+     */
+    void disable_formatting() {
+        set_formatting_enabled(false);
+    }
 
     /**
      * \brief Checks if color formatting is enabled.
@@ -334,9 +420,9 @@ private:
     bool  formatting_enabled_     = true;
     color text_color_             = color::white;
 
-    bool     has_shadow_    = false;
-    color    shadow_color_  = color::black;
-    vector2f shadow_offset_ = vector2f::zero;
+    bool     is_shadow_enabled_ = false;
+    color    shadow_color_      = color::black;
+    vector2f shadow_offset_     = vector2f::zero;
 };
 
 } // namespace lxgui::gui

--- a/include/lxgui/gui_frame.hpp
+++ b/include/lxgui/gui_frame.hpp
@@ -324,6 +324,19 @@ public:
     void create_title_region();
 
     /**
+     * \brief Enables or disables a layer.
+     * \param layer_id The id of the layer to disable
+     * \param enable 'true' to enable, 'false' to disable
+     */
+    void set_draw_layer_enabled(layer layer_id, bool enable) {
+        if (enable) {
+            enable_draw_layer(layer_id);
+        } else {
+            disable_draw_layer(layer_id);
+        }
+    }
+
+    /**
      * \brief Disables a layer.
      * \param layer_id The id of the layer to disable
      */
@@ -339,25 +352,89 @@ public:
      * \brief Sets if this frame can receive mouse input (click & move).
      * \param is_mouse_enabled 'true' to enable
      */
-    void enable_mouse(bool is_mouse_enabled);
+    void set_mouse_enabled(bool is_mouse_enabled);
+
+    /**
+     * \brief Marks this frame as able to receive mouse input (click & move).
+     * \see set_mouse_enabled()
+     */
+    void enable_mouse() {
+        set_mouse_enabled(true);
+    }
+
+    /**
+     * \brief Marks this frame as unable to receive mouse input (click & move).
+     * \see set_mouse_enabled()
+     */
+    void disable_mouse() {
+        set_mouse_enabled(false);
+    }
 
     /**
      * \brief Sets if this frame can receive mouse click input.
      * \param is_mouse_enabled 'true' to enable
      */
-    void enable_mouse_click(bool is_mouse_enabled);
+    void set_mouse_click_enabled(bool is_mouse_enabled);
+
+    /**
+     * \brief Marks this frame as able to receive mouse click input.
+     * \see set_mouse_click_enabled()
+     */
+    void enable_mouse_click() {
+        set_mouse_click_enabled(true);
+    }
+
+    /**
+     * \brief Marks this frame as unable to receive mouse click input.
+     * \see set_mouse_click_enabled()
+     */
+    void disable_mouse_click() {
+        set_mouse_click_enabled(false);
+    }
 
     /**
      * \brief Sets if this frame can receive mouse move input.
      * \param is_mouse_enabled 'true' to enable
      */
-    void enable_mouse_move(bool is_mouse_enabled);
+    void set_mouse_move_enabled(bool is_mouse_enabled);
+
+    /**
+     * \brief Marks this frame as able to receive mouse move input.
+     * \see set_mouse_move_enabled()
+     */
+    void enable_mouse_move() {
+        set_mouse_move_enabled(true);
+    }
+
+    /**
+     * \brief Marks this frame as unable to receive mouse move input.
+     * \see set_mouse_move_enabled()
+     */
+    void disable_mouse_move() {
+        set_mouse_move_enabled(false);
+    }
 
     /**
      * \brief Sets if this frame can receive mouse wheel input.
      * \param is_mouse_wheel_enabled 'true' to enable
      */
-    void enable_mouse_wheel(bool is_mouse_wheel_enabled);
+    void set_mouse_wheel_enabled(bool is_mouse_wheel_enabled);
+
+    /**
+     * \brief Marks this frame as able to receive mouse wheel input.
+     * \see set_mouse_wheel_enabled()
+     */
+    void enable_mouse_wheel() {
+        set_mouse_wheel_enabled(true);
+    }
+
+    /**
+     * \brief Marks this frame as unable to receive mouse wheel input.
+     * \see set_mouse_wheel_enabled()
+     */
+    void disable_mouse_wheel() {
+        set_mouse_wheel_enabled(false);
+    }
 
     /**
      * \brief Sets if this frame can receive any keyboard input.
@@ -367,8 +444,56 @@ public:
      * \see is_keyboard_enabled()
      * \see enable_key_capture()
      * \see is_key_capture_enabled()
+     * \see enable_keyboard()
+     * \see disable_keyboard()
      */
-    void enable_keyboard(bool is_keyboard_enabled);
+    void set_keyboard_enabled(bool is_keyboard_enabled);
+
+    /**
+     * \brief Marks this frame as able to receive any keyboard input.
+     * \see set_keyboard_enabled()
+     */
+    void enable_keyboard() {
+        set_keyboard_enabled(true);
+    }
+
+    /**
+     * \brief Marks this frame as unable to receive any keyboard input.
+     * \see set_keyboard_enabled()
+     */
+    void disable_keyboard() {
+        set_keyboard_enabled(false);
+    }
+
+    /**
+     * \brief Marks this frame as able to receive keyboard input from a specific key.
+     * \param key_name The key to capture
+     * \param enable 'true' to enable, 'false' to disable
+     * \see enable_key_capture()
+     * \see disable_key_capture()
+     */
+    void set_key_capture_enabled(const std::string& key_name, bool enable) {
+        if (enable) {
+            enable_key_capture(key_name);
+        } else {
+            disable_key_capture(key_name);
+        }
+    }
+
+    /**
+     * \brief Marks this frame as able to receive keyboard input from a specific key.
+     * \param key_id The key to capture
+     * \param enable 'true' to enable, 'false' to disable
+     * \see enable_key_capture()
+     * \see disable_key_capture()
+     */
+    void set_key_capture_enabled(input::key key_id, bool enable) {
+        if (enable) {
+            enable_key_capture(key_id);
+        } else {
+            disable_key_capture(key_id);
+        }
+    }
 
     /**
      * \brief Marks this frame as able to receive keyboard input from a specific key.
@@ -380,7 +505,7 @@ public:
      * simultaneously. Keyboard input must be enabled for capture to take place.
      * \see disable_key_capture()
      * \see is_key_capture_enabled()
-     * \see enable_keyboard()
+     * \see set_keyboard_enabled()
      * \see is_keyboard_enabled()
      */
     void enable_key_capture(const std::string& key_name);
@@ -393,7 +518,7 @@ public:
      * please use the overload taking a string.
      * \see disable_key_capture()
      * \see is_key_capture_enabled()
-     * \see enable_keyboard()
+     * \see set_keyboard_enabled()
      * \see is_keyboard_enabled()
      */
     void enable_key_capture(input::key key_id);
@@ -403,10 +528,11 @@ public:
      * \param key_name The key for which to disable capture
      * \see enable_key_capture()
      * \see is_key_capture_enabled()
-     * \see enable_keyboard()
+     * \see set_keyboard_enabled()
      * \see is_keyboard_enabled()
      */
     void disable_key_capture(const std::string& key_name);
+
     /**
      * \brief Marks this frame as unable to receive keyboard input from a specific key.
      * \param key_id The key for which to disable capture
@@ -415,7 +541,7 @@ public:
      * please use the overload taking a string.
      * \see enable_key_capture()
      * \see is_key_capture_enabled()
-     * \see enable_keyboard()
+     * \see set_keyboard_enabled()
      * \see is_keyboard_enabled()
      */
     void disable_key_capture(input::key key_id);
@@ -425,7 +551,7 @@ public:
      * \param key_name The key to capture
      * \see enable_key_capture()
      * \see is_key_capture_enabled()
-     * \see enable_keyboard()
+     * \see set_keyboard_enabled()
      * \see is_keyboard_enabled()
      */
     void disable_key_capture();
@@ -1227,6 +1353,32 @@ public:
      * \param event_name The name of the event
      */
     void unregister_event(const std::string& event_name);
+
+    /**
+     * \brief Tells this frame whether to react to mouse drag or not.
+     * \param button_name The mouse button to react to
+     * \param enable 'true' to enable, 'false' to disable
+     */
+    void set_drag_enabled(const std::string& button_name, bool enable) {
+        if (enable) {
+            enable_drag(button_name);
+        } else {
+            disable_drag(button_name);
+        }
+    }
+
+    /**
+     * \brief Tells this frame whether to react to mouse drag or not.
+     * \param button_id The mouse button to react to
+     * \param enable 'true' to enable, 'false' to disable
+     */
+    void set_drag_enabled(input::mouse_button button_id, bool enable) {
+        if (enable) {
+            enable_drag(button_id);
+        } else {
+            disable_drag(button_id);
+        }
+    }
 
     /**
      * \brief Tells this frame to react to mouse drag.

--- a/include/lxgui/gui_frame.hpp
+++ b/include/lxgui/gui_frame.hpp
@@ -295,7 +295,7 @@ public:
      * to use the frame again after calling this function, use
      * the helper class alive_checker.
      */
-    void update(float delta) override;
+    void update(float delta) final;
 
     /**
      * \brief Prints all relevant information about this region in a string.
@@ -1343,6 +1343,25 @@ public:
     virtual void fire_script(const std::string& script_name, const event_data& data = event_data{});
 
     /**
+     * \brief Sets a maximum update rate (in updates per seconds).
+     * \param rate The new rate, or 0 to update as often as possible
+     * \note The default is 0, which means the frame will be updated on each frame.
+     * If set to a value of 10, then the frame will be updated a maximum of 10 times per second.
+     * This can be useful to avoid wasting time updating a frame constantly, when less frequent
+     * updates would be sufficient.
+     * \warning Because update is triggered from parent to child, a frame's update rate will
+     * never be greater than that of its parent, even if this function is used to set the rate
+     * to a larger value.
+     */
+    void set_update_rate(float rate);
+
+    /**
+     * \brief Gets the maximum update rate (in upates per seconds).
+     * \return The maximum update rate (in upates per seconds)
+     */
+    float get_update_rate() const;
+
+    /**
      * \brief Tells this frame to react to a certain event.
      * \param event_name The name of the event
      */
@@ -1719,6 +1738,8 @@ protected:
 
     utils::observer_ptr<frame> parse_child_(const layout_node& node, const std::string& type);
 
+    virtual void update_(float delta);
+
     void check_position_();
 
     void add_level_(int amount);
@@ -1810,6 +1831,9 @@ protected:
     float max_height_ = std::numeric_limits<float>::infinity();
 
     float scale_ = 1.0f;
+
+    float update_rate_            = 0.0f;
+    float time_since_last_update_ = std::numeric_limits<float>::infinity();
 
     bool is_mouse_in_frame_ = false;
 

--- a/include/lxgui/gui_frame.hpp
+++ b/include/lxgui/gui_frame.hpp
@@ -80,13 +80,7 @@ using script_list_view = script_signal::slot_list_view;
  * when the frame is clicked, which effectively brings the frame to the
  * front.
  *
- * __Children and regions.__ When a frame is hidden, all its children
- * and regions will also be hidden. Likewise, deleting a frame will
- * automatically delete all its children and regions, unless they are
- * detached first. Other than this, children and regions do not need to
- * be located inside the frame; this is controlled purely by their anchors.
- * Therefore, if a child is not anchored to its parent, moving the parent
- * will not automatically move the child.
+ * __Children and layered regions.__ See the @ref region documentation.
  *
  * __Events.__ Frames can react to events. For this to happen, a callback
  * function must be registered to handle the corresponding event. There are

--- a/include/lxgui/gui_frame.hpp
+++ b/include/lxgui/gui_frame.hpp
@@ -743,15 +743,15 @@ public:
     /**
      * \brief Returns this frame's strata.
      * \return This frame's strata, or nullopt if the strata is inherited from the parent.
-     * \note See get_effective_frame_strata() to obtain the actual strata of this frame.
+     * \note See get_effective_strata() to obtain the actual strata of this frame.
      */
-    std::optional<frame_strata> get_frame_strata() const;
+    std::optional<strata> get_strata() const;
 
     /**
      * \brief Returns this frame's effective strata.
-     * \return This frame's strata, or its parent's effective strata if frame_strata::parent.
+     * \return This frame's strata, or its parent's effective strata if strata::parent.
      */
-    frame_strata get_effective_frame_strata() const;
+    strata get_effective_strata() const;
 
     /**
      * \brief Returns this frame's top-level parent.
@@ -1268,7 +1268,7 @@ public:
      * \brief Sets this frame's strata.
      * \param strata_id The new strata, or nullopt to inherit strata from parent
      */
-    void set_frame_strata(std::optional<frame_strata> strata_id);
+    void set_strata(std::optional<strata> strata_id);
 
     /**
      * \brief Sets this frames' backdrop.
@@ -1578,9 +1578,9 @@ protected:
             const_cast<const frame*>(this)->compute_top_level_frame_renderer_());
     }
 
-    frame_strata compute_effective_frame_strata_() const;
+    strata compute_effective_strata_() const;
 
-    void notify_frame_strata_changed_(frame_strata new_strata_id);
+    void notify_strata_changed_(strata new_strata_id);
 
     void notify_frame_renderer_changed_(const utils::observer_ptr<frame_renderer>& new_renderer);
 
@@ -1628,10 +1628,10 @@ protected:
     std::set<std::string> reg_drag_list_;
     std::set<std::string> reg_key_list_;
 
-    int                         level_ = 0;
-    std::optional<frame_strata> strata_;
-    frame_strata                effective_strata_ = frame_strata::medium;
-    bool                        is_top_level_     = false;
+    int                   level_ = 0;
+    std::optional<strata> strata_;
+    strata                effective_strata_ = strata::medium;
+    bool                  is_top_level_     = false;
 
     utils::observer_ptr<frame_renderer> frame_renderer_           = nullptr;
     utils::observer_ptr<frame_renderer> effective_frame_renderer_ = nullptr;

--- a/include/lxgui/gui_frame_renderer.hpp
+++ b/include/lxgui/gui_frame_renderer.hpp
@@ -32,7 +32,7 @@ public:
     frame_renderer& operator=(frame_renderer&&) = delete;
 
     /// Tells this renderer that one of its region requires redraw.
-    virtual void notify_strata_needs_redraw(frame_strata strata_id);
+    virtual void notify_strata_needs_redraw(strata strata_id);
 
     /**
      * \brief Tells this renderer that it should (or not) render another frame.
@@ -47,10 +47,8 @@ public:
      * \param old_strata_id The old frame strata
      * \param new_strata_id The new frame strata
      */
-    virtual void notify_frame_strata_changed(
-        const utils::observer_ptr<frame>& obj,
-        frame_strata                      old_strata_id,
-        frame_strata                      new_strata_id);
+    virtual void notify_strata_changed(
+        const utils::observer_ptr<frame>& obj, strata old_strata_id, strata new_strata_id);
 
     /**
      * \brief Tells this renderer that a frame has changed level.
@@ -59,7 +57,7 @@ public:
      * \param new_level The new frame level
      */
     virtual void
-    notify_frame_level_changed(const utils::observer_ptr<frame>& obj, int old_level, int new_level);
+    notify_level_changed(const utils::observer_ptr<frame>& obj, int old_level, int new_level);
 
     /**
      * \brief Returns the width and height of of this renderer's main render target (e.g., screen).
@@ -91,15 +89,15 @@ public:
      * \param strata_id The strata to inspect
      * \return The highest level on the provided strata
      */
-    int get_highest_level(frame_strata strata_id) const;
+    int get_highest_level(strata strata_id) const;
 
 protected:
     void clear_strata_list_();
     bool has_strata_list_changed_() const;
     void reset_strata_list_changed_flag_();
-    void notify_strata_needs_redraw_(strata& strata_obj);
+    void notify_strata_needs_redraw_(strata_data& strata_obj);
 
-    void render_strata_(const strata& strata_obj) const;
+    void render_strata_(const strata_data& strata_obj) const;
 
     struct frame_comparator {
         bool operator()(const frame* f1, const frame* f2) const;
@@ -108,13 +106,13 @@ protected:
     using frame_list_type     = utils::sorted_vector<frame*, frame_comparator>;
     using frame_list_iterator = frame_list_type::iterator;
 
-    std::pair<std::size_t, std::size_t> get_strata_range_(frame_strata strata_id) const;
+    std::pair<std::size_t, std::size_t> get_strata_range_(strata strata_id) const;
 
-    static constexpr std::size_t num_strata = magic_enum::enum_count<frame_strata>();
+    static constexpr std::size_t num_strata = magic_enum::enum_count<strata>();
 
-    std::array<strata, num_strata> strata_list_;
-    frame_list_type                sorted_frame_list_;
-    bool                           frame_list_updated_ = false;
+    std::array<strata_data, num_strata> strata_list_;
+    frame_list_type                     sorted_frame_list_;
+    bool                                frame_list_updated_ = false;
 };
 
 } // namespace lxgui::gui

--- a/include/lxgui/gui_region.hpp
+++ b/include/lxgui/gui_region.hpp
@@ -84,12 +84,19 @@ class frame_renderer;
  * For example, if an object is named `"$parentButton"` and its parent is named
  * `"ErrorMessage"`, the final name of the object will be `"ErrorMessageButton"`.
  * It can be accessed from the Lua state as `ErrorMessageButton`, or as
- * `ErrorMessage.Button`. Note that this is totally dynamic: if you later change
- * the parent of this button to be another frame, for example `"ExitDialog"`
- * its name will naturally change to `"ExitDialogButton"`, and it can be accessed
- * from Lua as `ExitDialogButton`, or as `ExitDialog.Button`. This is particularly
- * powerful for writing generic code which does not rely on the full names of
- * objects, only on their child-parent relationship.
+ * `ErrorMessage.Button`. This is particularly important when using inheritance,
+ * as the final name of an inherited child region then naturally depends on the
+ * name of its parent.
+ *
+ * A child will inherit some properties from its parent: transparency, scaling,
+ * visibility (show/hide), strata (if not explicitly specified), level
+ * (incremented from its parent's), and renderer (if not explicitly specified).
+ * Note in particular that the parent-child relationship does not impose any
+ * link between the child and its parent's position and size: this must be done
+ * explicitly with anchors, as required.
+ *
+ * Lastly, a child is *owned* by its parent: if the parent is destroyed, the
+ * child will be destroyed as well.
  *
  * __Positioning.__ regions have a position on the screen, but this is
  * not parameterized as a simple pair of X and Y coordinates. Instead, objects

--- a/include/lxgui/gui_renderer.hpp
+++ b/include/lxgui/gui_renderer.hpp
@@ -164,7 +164,6 @@ public:
     /**
      * \brief Returns the number of batches of vertices sent to the GPU since the last call to reset_counters.
      * \return The number of batches of vertices sent to the GPU since the last call to reset_counters
-     * \note This will be zero unless is_quad_batching_enabled() is 'true'.
      */
     std::size_t get_batch_count() const;
 

--- a/include/lxgui/gui_root.hpp
+++ b/include/lxgui/gui_root.hpp
@@ -287,7 +287,7 @@ public:
 
 private:
     void create_caching_render_target_();
-    void create_strata_cache_render_target_(strata& strata_obj);
+    void create_strata_cache_render_target_(strata_data& strata_obj);
 
     void clear_hovered_frame_();
     void update_hovered_frame_();

--- a/include/lxgui/gui_scroll_frame.hpp
+++ b/include/lxgui/gui_scroll_frame.hpp
@@ -44,15 +44,6 @@ public:
     ~scroll_frame() override;
 
     /**
-     * \brief Updates this region's logic.
-     * \param delta Time spent since last update
-     * \note Triggered callbacks could destroy the frame. If you need
-     * to use the frame again after calling this function, use
-     * the helper class alive_checker.
-     */
-    void update(float delta) override;
-
-    /**
      * \brief Copies a region's parameters into this scroll_frame (inheritance).
      * \param obj The region to copy
      */
@@ -175,6 +166,8 @@ public:
 protected:
     void         parse_all_nodes_before_children_(const layout_node& node) override;
     virtual void parse_scroll_child_node_(const layout_node& node);
+
+    void update_(float delta) override;
 
     const std::vector<std::string>& get_type_list_() const override;
 

--- a/include/lxgui/gui_scroll_frame.hpp
+++ b/include/lxgui/gui_scroll_frame.hpp
@@ -149,7 +149,7 @@ public:
     find_topmost_frame(const std::function<bool(const frame&)>& predicate) const override;
 
     /// Tells this renderer that one of its region requires redraw.
-    void notify_strata_needs_redraw(frame_strata strata_id) override;
+    void notify_strata_needs_redraw(strata strata_id) override;
 
     /**
      * \brief Tells this renderer that it should (or not) render another frame.

--- a/include/lxgui/gui_strata.hpp
+++ b/include/lxgui/gui_strata.hpp
@@ -13,22 +13,11 @@
 
 namespace lxgui::gui {
 
-class frame;
-
-enum class frame_strata {
-    background,
-    low,
-    medium,
-    high,
-    dialog,
-    fullscreen,
-    fullscreen_dialog,
-    tooltip
-};
+enum class strata { background, low, medium, high, dialog, fullscreen, fullscreen_dialog, tooltip };
 
 /// Contains frames sorted by level
-struct strata {
-    frame_strata                        id;
+struct strata_data {
+    strata                              id;
     std::pair<std::size_t, std::size_t> range;
     bool                                redraw_flag = true;
     std::shared_ptr<render_target>      target;

--- a/include/lxgui/gui_text.hpp
+++ b/include/lxgui/gui_text.hpp
@@ -393,6 +393,19 @@ public:
     quad create_letter_quad(char32_t c) const;
 
     /**
+     * \brief Sets whether this text object should use vertex caches or not.
+     * \note If vertex caches are not supported on the current rendering back end,
+     * this function has no effect.
+     */
+    void set_use_vertex_cache(bool use_vertex_cache);
+
+    /**
+     * \brief Checks if this text object is using vertex cache or not.
+     * \see set_use_vertex_cache()
+     */
+    bool get_use_vertex_cache() const;
+
+    /**
      * \brief Returns the renderer used to render this text.
      * \return The renderer used to render this text
      */
@@ -410,7 +423,10 @@ public:
 
 private:
     void update_() const;
+    void update_vertex_cache_() const;
+    bool use_vertex_cache_() const;
     void notify_cache_dirty_() const;
+    void notify_vertex_cache_dirty_() const;
 
     float round_to_pixel_(
         float value, utils::rounding_method method = utils::rounding_method::nearest) const;
@@ -446,6 +462,8 @@ private:
     mutable float       height_            = 0.0f;
     mutable std::size_t num_lines_         = 0u;
 
+    bool                                       use_vertex_cache_flag_    = false;
+    mutable bool                               update_vertex_cache_flag_ = false;
     mutable std::vector<std::array<vertex, 4>> quad_list_;
     mutable std::shared_ptr<vertex_cache>      vertex_cache_;
     mutable std::vector<std::array<vertex, 4>> outline_quad_list_;

--- a/include/lxgui/gui_text.hpp
+++ b/include/lxgui/gui_text.hpp
@@ -280,13 +280,25 @@ public:
     bool get_remove_starting_spaces() const;
 
     /**
-     * \brief Allows word wrap when the line is too long for the text box.
+     * \brief Allows/disallows word wrap when the line is too long for the text box.
      * \param wrap 'true' to enable word wrap
-     * \param add_ellipsis 'true' to put "..." at the end of a truncated line
      * \note Enabled by default.
      */
+    void set_word_wrap_enabled(bool wrap);
 
-    void enable_word_wrap(bool wrap, bool add_ellipsis);
+    /**
+     * \brief Allows word wrap when the line is too long for the text box.
+     */
+    void enable_word_wrap() {
+        set_word_wrap_enabled(true);
+    }
+
+    /**
+     * \brief Disallow word wrap when the line is too long for the text box.
+     */
+    void disable_word_wrap() {
+        set_word_wrap_enabled(false);
+    }
 
     /**
      * \brief Checks if word wrap is enabled.
@@ -295,11 +307,54 @@ public:
     bool is_word_wrap_enabled() const;
 
     /**
+     * \brief Sets whether to show an ellipsis "..." if words don't fit in the text box.
+     * \param add_ellipsis 'true' to put "..." at the end of a truncated line
+     * \note Disabled by default.
+     */
+    void set_word_ellipsis_enabled(bool add_ellipsis);
+
+    /**
+     * \brief Show an ellipsis "..." if words don't fit in the text box.
+     */
+    void enable_word_ellipsis() {
+        set_word_ellipsis_enabled(true);
+    }
+
+    /**
+     * \brief Do not show an ellipsis "..." if words don't fit in the text box.
+     */
+    void disable_word_ellipsis() {
+        set_word_ellipsis_enabled(false);
+    }
+
+    /**
+     * \brief Checks if word ellipsis is enabled.
+     * \return 'true' if word ellipsis is enabled
+     */
+    bool is_word_ellipsis_enabled() const;
+
+    /**
      * \brief Enables color formatting.
      * \param formatting 'true' to enable color formatting
      * \note Enabled by default. See \ref set_text for more information on formatting.
      */
-    void enable_formatting(bool formatting);
+    void set_formatting_enabled(bool formatting);
+
+    /**
+     * \brief Enables color formatting.
+     * \see set_formatting_enabled
+     */
+    void enable_formatting() {
+        set_formatting_enabled(true);
+    }
+
+    /**
+     * \brief Disables color formatting.
+     * \see set_formatting_enabled
+     */
+    void disable_formatting() {
+        set_formatting_enabled(false);
+    }
 
     /**
      * \brief Renders this text at the given position.

--- a/include/lxgui/utils_string.hpp
+++ b/include/lxgui/utils_string.hpp
@@ -8,15 +8,12 @@
 #include <algorithm>
 #include <array>
 #include <iostream>
+#include <locale>
 #include <magic_enum.hpp>
 #include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
-
-namespace std {
-class locale;
-}
 
 /** \cond INCLUDE_INTERNALS_IN_DOC
  */

--- a/include/lxgui/utils_string.hpp
+++ b/include/lxgui/utils_string.hpp
@@ -14,6 +14,10 @@
 #include <string_view>
 #include <vector>
 
+namespace std {
+class locale;
+}
+
 /** \cond INCLUDE_INTERNALS_IN_DOC
  */
 namespace lxgui::utils {
@@ -50,6 +54,60 @@ void replace(string& s, string_view pattern, string_view replacement);
 [[nodiscard]] std::size_t hex_to_uint(string_view s);
 
 namespace impl {
+
+template<typename T>
+std::optional<T> from_string(const std::locale&, string_view);
+
+template<>
+std::optional<int> from_string<int>(const std::locale&, string_view);
+
+template<>
+std::optional<long> from_string<long>(const std::locale&, string_view);
+
+template<>
+std::optional<long long> from_string<long long>(const std::locale&, string_view);
+
+template<>
+std::optional<unsigned> from_string<unsigned>(const std::locale&, string_view);
+
+template<>
+std::optional<unsigned long> from_string<unsigned long>(const std::locale&, string_view);
+
+template<>
+std::optional<unsigned long long> from_string<unsigned long long>(const std::locale&, string_view);
+
+template<>
+std::optional<float> from_string<float>(const std::locale&, string_view);
+
+template<>
+std::optional<double> from_string<double>(const std::locale&, string_view);
+
+template<typename T>
+std::optional<T> from_string(const std::locale&, ustring_view);
+
+template<>
+std::optional<int> from_string<int>(const std::locale&, ustring_view);
+
+template<>
+std::optional<long> from_string<long>(const std::locale&, ustring_view);
+
+template<>
+std::optional<long long> from_string<long long>(const std::locale&, ustring_view);
+
+template<>
+std::optional<unsigned> from_string<unsigned>(const std::locale&, ustring_view);
+
+template<>
+std::optional<unsigned long> from_string<unsigned long>(const std::locale&, ustring_view);
+
+template<>
+std::optional<unsigned long long> from_string<unsigned long long>(const std::locale&, ustring_view);
+
+template<>
+std::optional<float> from_string<float>(const std::locale&, ustring_view);
+
+template<>
+std::optional<double> from_string<double>(const std::locale&, ustring_view);
 
 template<typename T>
 std::optional<T> from_string(string_view);
@@ -120,6 +178,24 @@ std::optional<ustring> from_string<ustring>(ustring_view);
 } // namespace impl
 
 template<typename T>
+[[nodiscard]] std::optional<T> from_string(const std::locale& loc, string_view s) {
+    if constexpr (std::is_enum_v<T>) {
+        return magic_enum::enum_cast<T>(s, magic_enum::case_insensitive);
+    } else {
+        return impl::from_string<T>(loc, s);
+    }
+}
+
+template<typename T>
+[[nodiscard]] std::optional<T> from_string(const std::locale& loc, ustring_view s) {
+    if constexpr (std::is_enum_v<T>) {
+        return magic_enum::enum_cast<T>(unicode_to_utf8(s), magic_enum::case_insensitive);
+    } else {
+        return impl::from_string<T>(loc, s);
+    }
+}
+
+template<typename T>
 [[nodiscard]] std::optional<T> from_string(string_view s) {
     if constexpr (std::is_enum_v<T>) {
         return magic_enum::enum_cast<T>(s, magic_enum::case_insensitive);
@@ -137,14 +213,21 @@ template<typename T>
     }
 }
 
+[[nodiscard]] bool is_number(const std::locale& loc, string_view s);
+[[nodiscard]] bool is_number(const std::locale& loc, ustring_view s);
+[[nodiscard]] bool is_integer(const std::locale& loc, string_view s);
+[[nodiscard]] bool is_integer(const std::locale& loc, ustring_view s);
+
 [[nodiscard]] bool is_number(string_view s);
 [[nodiscard]] bool is_number(ustring_view s);
-[[nodiscard]] bool is_number(char s);
-[[nodiscard]] bool is_number(char32_t s);
 [[nodiscard]] bool is_integer(string_view s);
 [[nodiscard]] bool is_integer(ustring_view s);
+
+[[nodiscard]] bool is_number(char s);
+[[nodiscard]] bool is_number(char32_t s);
 [[nodiscard]] bool is_integer(char s);
 [[nodiscard]] bool is_integer(char32_t s);
+
 [[nodiscard]] bool is_boolean(string_view s);
 [[nodiscard]] bool is_boolean(ustring_view s);
 

--- a/src/gui_animated_texture_glues.cpp
+++ b/src/gui_animated_texture_glues.cpp
@@ -19,7 +19,7 @@ namespace lxgui::gui {
 
 void animated_texture::register_on_lua(sol::state& lua) {
     auto type = lua.new_usertype<animated_texture>(
-        "AnimatedTexture", sol::base_classes, sol::bases<region, layered_region>(),
+        animated_texture::class_name, sol::base_classes, sol::bases<region, layered_region>(),
         sol::meta_function::index, member_function<&animated_texture::get_lua_member_>(),
         sol::meta_function::new_index, member_function<&animated_texture::set_lua_member_>());
 

--- a/src/gui_button.cpp
+++ b/src/gui_button.cpp
@@ -15,7 +15,7 @@ button::button(utils::control_block& block, manager& mgr, const frame_core_attri
 
     initialize_(*this, attr);
 
-    enable_mouse(true);
+    enable_mouse();
 }
 
 std::string button::serialize(const std::string& tab) const {

--- a/src/gui_button_glues.cpp
+++ b/src/gui_button_glues.cpp
@@ -43,9 +43,9 @@ namespace lxgui::gui {
 
 void button::register_on_lua(sol::state& lua) {
     auto type = lua.new_usertype<button>(
-        "Button", sol::base_classes, sol::bases<region, frame>(), sol::meta_function::index,
-        member_function<&button::get_lua_member_>(), sol::meta_function::new_index,
-        member_function<&button::set_lua_member_>());
+        button::class_name, sol::base_classes, sol::bases<region, frame>(),
+        sol::meta_function::index, member_function<&button::get_lua_member_>(),
+        sol::meta_function::new_index, member_function<&button::set_lua_member_>());
 
     /** @function click
      */

--- a/src/gui_button_glues.cpp
+++ b/src/gui_button_glues.cpp
@@ -226,6 +226,10 @@ void button::register_on_lua(sol::state& lua) {
      */
     type.set_function("set_disabled_texture", member_function<&button::set_disabled_texture>());
 
+    /** @function set_enabled
+     */
+    type.set_function("set_enabled", member_function<&button::set_enabled>());
+
     /** @function set_highlight_font_object
      */
     type.set_function("set_highlight_font_object", member_function<&button::set_highlight_text>());

--- a/src/gui_check_button_glues.cpp
+++ b/src/gui_check_button_glues.cpp
@@ -19,7 +19,7 @@ namespace lxgui::gui {
 
 void check_button::register_on_lua(sol::state& lua) {
     auto type = lua.new_usertype<check_button>(
-        "CheckButton", sol::base_classes, sol::bases<region, frame, button>(),
+        check_button::class_name, sol::base_classes, sol::bases<region, frame, button>(),
         sol::meta_function::index, member_function<&check_button::get_lua_member_>(),
         sol::meta_function::new_index, member_function<&check_button::set_lua_member_>());
 

--- a/src/gui_edit_box.cpp
+++ b/src/gui_edit_box.cpp
@@ -70,10 +70,10 @@ void edit_box::copy_from(const region& obj) {
     }
 }
 
-void edit_box::update(float delta) {
+void edit_box::update_(float delta) {
     alive_checker checker(*this);
 
-    base::update(delta);
+    base::update_(delta);
     if (!checker.is_alive())
         return;
 

--- a/src/gui_edit_box.cpp
+++ b/src/gui_edit_box.cpp
@@ -18,7 +18,7 @@ namespace lxgui::gui {
 
 edit_box::edit_box(utils::control_block& block, manager& mgr, const frame_core_attributes& attr) :
     frame(block, mgr, attr),
-    carret_timer_(blink_period_, utils::periodic_timer::start_type::first_tick, false) {
+    carret_timer_(blink_time_, utils::periodic_timer::start_type::first_tick, false) {
 
     initialize_(*this, attr);
 
@@ -46,7 +46,7 @@ void edit_box::copy_from(const region& obj) {
         return;
 
     this->set_max_letters(box_obj->get_max_letters());
-    this->set_blink_period(box_obj->get_blink_period());
+    this->set_blink_time(box_obj->get_blink_time());
     this->set_numeric_only(box_obj->is_numeric_only());
     this->set_positive_only(box_obj->is_positive_only());
     this->set_integer_only(box_obj->is_integer_only());
@@ -361,17 +361,17 @@ std::size_t edit_box::get_letter_count() const {
     return unicode_text_.size();
 }
 
-void edit_box::set_blink_period(double blink_period) {
-    if (blink_period_ == blink_period)
+void edit_box::set_blink_time(double blink_time) {
+    if (blink_time_ == blink_time)
         return;
 
-    blink_period_ = blink_period;
+    blink_time_ = blink_time;
     carret_timer_ =
-        utils::periodic_timer(blink_period_, utils::periodic_timer::start_type::first_tick, false);
+        utils::periodic_timer(blink_time_, utils::periodic_timer::start_type::first_tick, false);
 }
 
-double edit_box::get_blink_period() const {
-    return blink_period_;
+double edit_box::get_blink_time() const {
+    return blink_time_;
 }
 
 void edit_box::set_numeric_only(bool numeric_only) {

--- a/src/gui_edit_box.cpp
+++ b/src/gui_edit_box.cpp
@@ -507,7 +507,7 @@ const std::vector<utils::ustring>& edit_box::get_history_lines() const {
     return history_line_list_;
 }
 
-void edit_box::clear_history() {
+void edit_box::clear_history_lines() {
     history_line_list_.clear();
     current_history_line_ = std::numeric_limits<std::size_t>::max();
 }

--- a/src/gui_edit_box.cpp
+++ b/src/gui_edit_box.cpp
@@ -25,10 +25,9 @@ edit_box::edit_box(utils::control_block& block, manager& mgr, const frame_core_a
     iter_carret_pos_     = unicode_text_.begin();
     iter_carret_pos_old_ = unicode_text_.begin();
 
-    enable_mouse(true);
+    enable_mouse();
     enable_drag(input::mouse_button::left);
-
-    enable_keyboard(true);
+    enable_keyboard();
 }
 
 bool edit_box::can_use_script(const std::string& script_name) const {
@@ -51,7 +50,7 @@ void edit_box::copy_from(const region& obj) {
     this->set_numeric_only(box_obj->is_numeric_only());
     this->set_positive_only(box_obj->is_positive_only());
     this->set_integer_only(box_obj->is_integer_only());
-    this->enable_password_mode(box_obj->is_password_mode_enabled());
+    this->set_password_mode_enabled(box_obj->is_password_mode_enabled());
     this->set_multi_line(box_obj->is_multi_line());
     this->set_max_history_lines(box_obj->get_max_history_lines());
     this->set_text_insets(box_obj->get_text_insets());
@@ -429,7 +428,7 @@ bool edit_box::is_integer_only() const {
     return is_integer_only_;
 }
 
-void edit_box::enable_password_mode(bool enable) {
+void edit_box::set_password_mode_enabled(bool enable) {
     if (is_password_mode_ == enable)
         return;
 
@@ -450,8 +449,10 @@ void edit_box::set_multi_line(bool multi_line) {
 
     is_multi_line_ = multi_line;
 
-    if (font_string_)
-        font_string_->set_word_wrap(is_multi_line_, is_multi_line_);
+    if (font_string_) {
+        font_string_->set_word_wrap_enabled(is_multi_line_);
+        font_string_->set_word_ellipsis_enabled(is_multi_line_);
+    }
 
     check_text_();
     iter_carret_pos_ = unicode_text_.end();
@@ -569,7 +570,8 @@ void edit_box::set_font_string(utils::observer_ptr<font_string> fstr) {
     if (!font_string_)
         return;
 
-    font_string_->set_word_wrap(is_multi_line_, is_multi_line_);
+    font_string_->set_word_wrap_enabled(is_multi_line_);
+    font_string_->set_word_ellipsis_enabled(is_multi_line_);
 
     font_string_->set_dimensions(vector2f(0, 0));
     font_string_->clear_all_anchors();
@@ -577,7 +579,7 @@ void edit_box::set_font_string(utils::observer_ptr<font_string> fstr) {
     font_string_->set_anchor(point::top_left, text_insets_.top_left());
     font_string_->set_anchor(point::bottom_right, -text_insets_.bottom_right());
 
-    font_string_->enable_formatting(false);
+    font_string_->disable_formatting();
 
     create_carret_();
 }
@@ -585,7 +587,8 @@ void edit_box::set_font_string(utils::observer_ptr<font_string> fstr) {
 void edit_box::set_font(const std::string& font_name, float height) {
     create_font_string_();
 
-    font_string_->set_font(font_name, height);
+    if (font_string_)
+        font_string_->set_font(font_name, height);
 
     create_carret_();
 }

--- a/src/gui_edit_box_glues.cpp
+++ b/src/gui_edit_box_glues.cpp
@@ -69,9 +69,9 @@ void edit_box::register_on_lua(sol::state& lua) {
         self.add_history_line(utils::utf8_to_unicode(line));
     });
 
-    /** @function clear_history
+    /** @function clear_history_lines
      */
-    type.set_function("clear_history", member_function<&edit_box::clear_history>());
+    type.set_function("clear_history_lines", member_function<&edit_box::clear_history_lines>());
 
     /** @function disable_password_mode
      */

--- a/src/gui_edit_box_glues.cpp
+++ b/src/gui_edit_box_glues.cpp
@@ -106,9 +106,8 @@ void edit_box::register_on_lua(sol::state& lua) {
     /** @function get_number
      */
     type.set_function("get_number", [](const edit_box& self) {
-        // TODO: use localizer's locale for that
-        // https://github.com/cschreib/lxgui/issues/88
-        return utils::from_string<double>(self.get_text()).value_or(0.0);
+        const auto& locale = self.get_manager().get_localizer().get_locale();
+        return utils::from_string<double>(locale, self.get_text()).value_or(0.0);
     });
 
     /** @function get_text

--- a/src/gui_edit_box_glues.cpp
+++ b/src/gui_edit_box_glues.cpp
@@ -73,6 +73,14 @@ void edit_box::register_on_lua(sol::state& lua) {
      */
     type.set_function("clear_history", member_function<&edit_box::clear_history>());
 
+    /** @function disable_password_mode
+     */
+    type.set_function("disable_password_mode", member_function<&edit_box::disable_password_mode>());
+
+    /** @function enable_password_mode
+     */
+    type.set_function("enable_password_mode", member_function<&edit_box::enable_password_mode>());
+
     /** @function get_blink_period
      */
     type.set_function("get_blink_period", member_function<&edit_box::get_blink_period>());
@@ -138,9 +146,10 @@ void edit_box::register_on_lua(sol::state& lua) {
      */
     type.set_function("is_numeric", member_function<&edit_box::is_numeric_only>());
 
-    /** @function is_password
+    /** @function is_password_mode_enabled
      */
-    type.set_function("is_password", member_function<&edit_box::is_password_mode_enabled>());
+    type.set_function(
+        "is_password_mode_enabled", member_function<&edit_box::is_password_mode_enabled>());
 
     /** @function set_blink_period
      */
@@ -204,9 +213,10 @@ void edit_box::register_on_lua(sol::state& lua) {
      */
     type.set_function("set_numeric", member_function<&edit_box::set_numeric_only>());
 
-    /** @function set_password
+    /** @function set_password_mode_enabled
      */
-    type.set_function("set_password", member_function<&edit_box::enable_password_mode>());
+    type.set_function(
+        "set_password_mode_enabled", member_function<&edit_box::set_password_mode_enabled>());
 
     /** @function set_text
      */

--- a/src/gui_edit_box_glues.cpp
+++ b/src/gui_edit_box_glues.cpp
@@ -59,9 +59,9 @@ namespace lxgui::gui {
 
 void edit_box::register_on_lua(sol::state& lua) {
     auto type = lua.new_usertype<edit_box>(
-        "EditBox", sol::base_classes, sol::bases<region, frame>(), sol::meta_function::index,
-        member_function<&edit_box::get_lua_member_>(), sol::meta_function::new_index,
-        member_function<&edit_box::set_lua_member_>());
+        edit_box::class_name, sol::base_classes, sol::bases<region, frame>(),
+        sol::meta_function::index, member_function<&edit_box::get_lua_member_>(),
+        sol::meta_function::new_index, member_function<&edit_box::set_lua_member_>());
 
     /** @function add_history_line
      */

--- a/src/gui_edit_box_glues.cpp
+++ b/src/gui_edit_box_glues.cpp
@@ -81,9 +81,9 @@ void edit_box::register_on_lua(sol::state& lua) {
      */
     type.set_function("enable_password_mode", member_function<&edit_box::enable_password_mode>());
 
-    /** @function get_blink_period
+    /** @function get_blink_time
      */
-    type.set_function("get_blink_period", member_function<&edit_box::get_blink_period>());
+    type.set_function("get_blink_time", member_function<&edit_box::get_blink_time>());
 
     /** @function get_cursor_position
      */
@@ -151,9 +151,9 @@ void edit_box::register_on_lua(sol::state& lua) {
     type.set_function(
         "is_password_mode_enabled", member_function<&edit_box::is_password_mode_enabled>());
 
-    /** @function set_blink_period
+    /** @function set_blink_time
      */
-    type.set_function("set_blink_period", member_function<&edit_box::set_blink_period>());
+    type.set_function("set_blink_time", member_function<&edit_box::set_blink_time>());
 
     /** @function set_cursor_position
      */

--- a/src/gui_edit_box_parser.cpp
+++ b/src/gui_edit_box_parser.cpp
@@ -11,8 +11,8 @@ void edit_box::parse_attributes_(const layout_node& node) {
     if (const layout_attribute* attr = node.try_get_attribute("letters"))
         set_max_letters(attr->get_value<std::size_t>());
 
-    if (const layout_attribute* attr = node.try_get_attribute("blinkPeriod"))
-        set_blink_period(attr->get_value<float>());
+    if (const layout_attribute* attr = node.try_get_attribute("blinkTime"))
+        set_blink_time(attr->get_value<float>());
 
     if (const layout_attribute* attr = node.try_get_attribute("numeric"))
         set_numeric_only(attr->get_value<bool>());

--- a/src/gui_edit_box_parser.cpp
+++ b/src/gui_edit_box_parser.cpp
@@ -24,7 +24,7 @@ void edit_box::parse_attributes_(const layout_node& node) {
         set_integer_only(attr->get_value<bool>());
 
     if (const layout_attribute* attr = node.try_get_attribute("password"))
-        enable_password_mode(attr->get_value<bool>());
+        set_password_mode_enabled(attr->get_value<bool>());
 
     if (const layout_attribute* attr = node.try_get_attribute("multiLine"))
         set_multi_line(attr->get_value<bool>());

--- a/src/gui_font_string.cpp
+++ b/src/gui_font_string.cpp
@@ -50,7 +50,7 @@ void font_string::render() const {
 
     text_->set_alpha(get_effective_alpha());
 
-    if (has_shadow_) {
+    if (is_shadow_enabled_) {
         text_->set_color(shadow_color_, true);
         text_->render(matrix4f::translation(round_to_pixel(pos + shadow_offset_)));
     }
@@ -77,7 +77,7 @@ std::string font_string::serialize(const std::string& tab) const {
     str << tab << "  |   # vertical  : " << utils::to_string(align_y_) << "\n";
     str << tab << "  #-###\n";
     str << tab << "  # NonSpaceW. : " << non_space_wrap_enabled_ << "\n";
-    if (has_shadow_) {
+    if (is_shadow_enabled_) {
         str << tab << "  # Shadow off.: (" << shadow_offset_.x << ", " << shadow_offset_.y << ")\n";
         str << tab << "  # Shadow col.: " << shadow_color_ << "\n";
     }
@@ -103,13 +103,13 @@ void font_string::copy_from(const region& obj) {
     this->set_line_spacing(fstr_obj->get_line_spacing());
     this->set_text(fstr_obj->get_text());
     this->set_outlined(fstr_obj->is_outlined());
-    if (fstr_obj->has_shadow()) {
-        this->set_shadow(true);
+    if (fstr_obj->is_shadow_enabled()) {
+        this->set_shadow_enabled(true);
         this->set_shadow_color(fstr_obj->get_shadow_color());
         this->set_shadow_offset(fstr_obj->get_shadow_offset());
     }
     this->set_text_color(fstr_obj->get_text_color());
-    this->set_non_space_wrap(fstr_obj->can_non_space_wrap());
+    this->set_non_space_wrap_enabled(fstr_obj->is_non_space_wrap_enabled());
 }
 
 const std::string& font_string::get_font_name() const {
@@ -206,8 +206,9 @@ void font_string::create_text_object_() {
     text_->set_alignment_x(align_x_);
     text_->set_alignment_y(align_y_);
     text_->set_tracking(spacing_);
-    text_->enable_word_wrap(word_wrap_enabled_, ellipsis_enabled_);
-    text_->enable_formatting(formatting_enabled_);
+    text_->set_word_wrap_enabled(word_wrap_enabled_);
+    text_->set_word_ellipsis_enabled(ellipsis_enabled_);
+    text_->set_formatting_enabled(formatting_enabled_);
 }
 
 void font_string::set_font(const std::string& font_name, float height) {
@@ -253,7 +254,7 @@ void font_string::set_shadow_color(const color& shadow_color) {
         return;
 
     shadow_color_ = shadow_color;
-    if (has_shadow_ && !is_virtual_)
+    if (is_shadow_enabled_ && !is_virtual_)
         notify_renderer_need_redraw();
 }
 
@@ -262,7 +263,7 @@ void font_string::set_shadow_offset(const vector2f& shadow_offset) {
         return;
 
     shadow_offset_ = shadow_offset;
-    if (has_shadow_ && !is_virtual_)
+    if (is_shadow_enabled_ && !is_virtual_)
         notify_renderer_need_redraw();
 }
 
@@ -308,7 +309,7 @@ void font_string::set_text_color(const color& text_color) {
         notify_renderer_need_redraw();
 }
 
-bool font_string::can_non_space_wrap() const {
+bool font_string::is_non_space_wrap_enabled() const {
     return non_space_wrap_enabled_;
 }
 
@@ -337,43 +338,52 @@ const utils::ustring& font_string::get_text() const {
     return content_;
 }
 
-void font_string::set_non_space_wrap(bool can_non_space_wrap) {
-    if (non_space_wrap_enabled_ == can_non_space_wrap)
+void font_string::set_non_space_wrap_enabled(bool is_non_space_wrap_enabled) {
+    if (non_space_wrap_enabled_ == is_non_space_wrap_enabled)
         return;
 
-    non_space_wrap_enabled_ = can_non_space_wrap;
+    non_space_wrap_enabled_ = is_non_space_wrap_enabled;
     if (!is_virtual_)
         notify_renderer_need_redraw();
 }
 
-bool font_string::has_shadow() const {
-    return has_shadow_;
+bool font_string::is_shadow_enabled() const {
+    return is_shadow_enabled_;
 }
 
-void font_string::set_shadow(bool has_shadow) {
-    if (has_shadow_ == has_shadow)
+void font_string::set_shadow_enabled(bool is_shadow_enabled) {
+    if (is_shadow_enabled_ == is_shadow_enabled)
         return;
 
-    has_shadow_ = has_shadow;
+    is_shadow_enabled_ = is_shadow_enabled;
     if (!is_virtual_)
         notify_renderer_need_redraw();
 }
 
-void font_string::set_word_wrap(bool can_word_wrap, bool add_ellipsis) {
-    word_wrap_enabled_ = can_word_wrap;
-    ellipsis_enabled_  = add_ellipsis;
+void font_string::set_word_wrap_enabled(bool enabled) {
+    word_wrap_enabled_ = enabled;
     if (text_)
-        text_->enable_word_wrap(word_wrap_enabled_, ellipsis_enabled_);
+        text_->set_word_wrap_enabled(word_wrap_enabled_);
 }
 
-bool font_string::can_word_wrap() const {
+bool font_string::is_word_wrap_enabled() const {
     return word_wrap_enabled_;
 }
 
-void font_string::enable_formatting(bool formatting) {
+void font_string::set_word_ellipsis_enabled(bool enabled) {
+    ellipsis_enabled_ = enabled;
+    if (text_)
+        text_->set_word_ellipsis_enabled(ellipsis_enabled_);
+}
+
+bool font_string::is_word_ellipsis_enabled() const {
+    return ellipsis_enabled_;
+}
+
+void font_string::set_formatting_enabled(bool formatting) {
     formatting_enabled_ = formatting;
     if (text_)
-        text_->enable_formatting(formatting_enabled_);
+        text_->set_formatting_enabled(formatting_enabled_);
 }
 
 bool font_string::is_formatting_enabled() const {

--- a/src/gui_font_string.cpp
+++ b/src/gui_font_string.cpp
@@ -24,6 +24,8 @@ void font_string::render() const {
     if (!text_ || !is_ready_ || !is_visible())
         return;
 
+    text_->set_use_vertex_cache(is_vertex_cache_used_());
+
     vector2f pos;
 
     if (std::isinf(text_->get_box_width())) {
@@ -395,11 +397,31 @@ void font_string::set_text(const utils::ustring& content) {
         return;
 
     content_ = content;
+
     if (text_) {
         text_->set_text(content_);
         if (!is_virtual_)
             notify_borders_need_update();
     }
+}
+
+bool font_string::is_vertex_cache_used_() const {
+    auto& renderer = get_manager().get_renderer();
+    switch (vertex_cache_strategy_) {
+    case vertex_cache_strategy::always_disabled: return false;
+    case vertex_cache_strategy::prefer_enabled: return renderer.is_vertex_cache_enabled();
+    case vertex_cache_strategy::always_enabled: return true;
+    case vertex_cache_strategy::automatic:
+        return renderer.is_vertex_cache_enabled() && !renderer.is_quad_batching_enabled();
+    }
+}
+
+void font_string::set_vertex_cache_strategy(vertex_cache_strategy strategy) {
+    vertex_cache_strategy_ = strategy;
+}
+
+vertex_cache_strategy font_string::get_vertex_cache_strategy() const {
+    return vertex_cache_strategy_;
 }
 
 text* font_string::get_text_object() {

--- a/src/gui_font_string_glues.cpp
+++ b/src/gui_font_string_glues.cpp
@@ -276,6 +276,12 @@ void font_string::register_on_lua(sol::state& lua) {
         return utils::unicode_to_utf8(self.get_text());
     });
 
+    /** @function get_vertex_cache_strategy
+     */
+    type.set_function("get_vertex_cache_strategy", [](const font_string& self) {
+        return utils::to_string(self.get_vertex_cache_strategy());
+    });
+
     /** @function is_formatting_enabled
      */
     type.set_function(
@@ -316,6 +322,19 @@ void font_string::register_on_lua(sol::state& lua) {
             [](font_string& self, const std::string& text) {
                 self.set_text(utils::utf8_to_unicode(text));
             }));
+
+    /** @function set_vertex_cache_strategy
+     */
+    type.set_function(
+        "set_vertex_cache_strategy", [](font_string& self, const std::string& strategy_name) {
+            if (auto strategy = utils::from_string<vertex_cache_strategy>(strategy_name);
+                strategy.has_value()) {
+                self.set_vertex_cache_strategy(strategy.value());
+            } else {
+                gui::out << gui::warning << "font_string:set_vertex_cache_strategy: "
+                         << "Unknown strategy: \"" << strategy_name << "\"." << std::endl;
+            }
+        });
 }
 
 } // namespace lxgui::gui

--- a/src/gui_font_string_glues.cpp
+++ b/src/gui_font_string_glues.cpp
@@ -75,6 +75,50 @@ void font_string::register_on_lua(sol::state& lua) {
         sol::meta_function::index, member_function<&font_string::get_lua_member_>(),
         sol::meta_function::new_index, member_function<&font_string::set_lua_member_>());
 
+    /** @function disable_formatting
+     */
+    type.set_function("disable_formatting", member_function<&font_string::disable_formatting>());
+
+    /** @function disable_non_space_wrap
+     */
+    type.set_function(
+        "disable_non_space_wrap", member_function<&font_string::disable_non_space_wrap>());
+
+    /** @function disable_shadow
+     */
+    type.set_function("disable_shadow", member_function<&font_string::disable_shadow>());
+
+    /** @function disable_word_ellipsis
+     */
+    type.set_function(
+        "disable_word_ellipsis", member_function<&font_string::disable_word_ellipsis>());
+
+    /** @function disable_word_wrap
+     */
+    type.set_function("disable_word_wrap", member_function<&font_string::disable_word_wrap>());
+
+    /** @function enable_formatting
+     */
+    type.set_function("enable_formatting", member_function<&font_string::enable_formatting>());
+
+    /** @function enable_non_space_wrap
+     */
+    type.set_function(
+        "enable_non_space_wrap", member_function<&font_string::enable_non_space_wrap>());
+
+    /** @function enable_shadow
+     */
+    type.set_function("enable_shadow", member_function<&font_string::enable_shadow>());
+
+    /** @function enable_word_ellipsis
+     */
+    type.set_function(
+        "enable_word_ellipsis", member_function<&font_string::enable_word_ellipsis>());
+
+    /** @function enable_word_wrap
+     */
+    type.set_function("enable_word_wrap", member_function<&font_string::enable_word_wrap>());
+
     /** @function get_font
      */
     type.set_function("get_font", member_function<&font_string::get_font_name>());
@@ -198,13 +242,15 @@ void font_string::register_on_lua(sol::state& lua) {
             },
             [](font_string& self, const std::string& s) { self.set_text_color(color(s)); }));
 
-    /** @function can_non_space_wrap
+    /** @function is_non_space_wrap_enabled
      */
-    type.set_function("can_non_space_wrap", member_function<&font_string::can_non_space_wrap>());
+    type.set_function(
+        "is_non_space_wrap_enabled", member_function<&font_string::is_non_space_wrap_enabled>());
 
-    /** @function can_word_wrap
+    /** @function is_word_wrap_enabled
      */
-    type.set_function("can_word_wrap", member_function<&font_string::can_word_wrap>());
+    type.set_function(
+        "is_word_wrap_enabled", member_function<&font_string::is_word_wrap_enabled>());
 
     /** @function enable_formatting
      */
@@ -235,16 +281,20 @@ void font_string::register_on_lua(sol::state& lua) {
     type.set_function(
         "is_formatting_enabled", member_function<&font_string::is_formatting_enabled>());
 
-    /** @function set_non_space_wrap
-     */
-    type.set_function("set_non_space_wrap", member_function<&font_string::set_non_space_wrap>());
-
-    /** @function set_word_wrap
+    /** @function set_non_space_wrap_enabled
      */
     type.set_function(
-        "set_word_wrap", [](font_string& self, bool wrap, sol::optional<bool> ellipsis) {
-            self.set_word_wrap(wrap, ellipsis.value_or(false));
-        });
+        "set_non_space_wrap_enabled", member_function<&font_string::set_non_space_wrap_enabled>());
+
+    /** @function set_word_wrap_enabled
+     */
+    type.set_function(
+        "set_word_wrap_enabled", member_function<&font_string::set_word_wrap_enabled>());
+
+    /** @function set_word_ellipsis_enabled
+     */
+    type.set_function(
+        "set_word_ellipsis_enabled", member_function<&font_string::set_word_ellipsis_enabled>());
 
     /** @function set_text
      */

--- a/src/gui_font_string_glues.cpp
+++ b/src/gui_font_string_glues.cpp
@@ -71,7 +71,7 @@ namespace lxgui::gui {
 
 void font_string::register_on_lua(sol::state& lua) {
     auto type = lua.new_usertype<font_string>(
-        "FontString", sol::base_classes, sol::bases<region, layered_region>(),
+        font_string::class_name, sol::base_classes, sol::bases<region, layered_region>(),
         sol::meta_function::index, member_function<&font_string::get_lua_member_>(),
         sol::meta_function::new_index, member_function<&font_string::set_lua_member_>());
 

--- a/src/gui_font_string_parser.cpp
+++ b/src/gui_font_string_parser.cpp
@@ -29,10 +29,8 @@ void font_string::parse_attributes_(const layout_node& node) {
 
     if (const layout_attribute* attr = node.try_get_attribute("nonSpaceWrap"))
         set_non_space_wrap_enabled(attr->get_value<bool>());
-
     if (const layout_attribute* attr = node.try_get_attribute("spacing"))
         set_spacing(attr->get_value<float>());
-
     if (const layout_attribute* attr = node.try_get_attribute("lineSpacing"))
         set_line_spacing(attr->get_value<float>());
 
@@ -49,35 +47,12 @@ void font_string::parse_attributes_(const layout_node& node) {
         }
     }
 
-    if (const layout_attribute* attr = node.try_get_attribute("alignX")) {
-        const std::string& align_x = attr->get_value<std::string>();
-        if (align_x == "LEFT")
-            set_alignment_x(alignment_x::left);
-        else if (align_x == "CENTER")
-            set_alignment_x(alignment_x::center);
-        else if (align_x == "RIGHT")
-            set_alignment_x(alignment_x::right);
-        else {
-            gui::out << gui::warning << node.get_location() << ": "
-                     << "Unknown horizontal alignment behavior for " << name_ << ": \"" << align_x
-                     << "\"." << std::endl;
-        }
-    }
-
-    if (const layout_attribute* attr = node.try_get_attribute("alignY")) {
-        const std::string& align_y = attr->get_value<std::string>();
-        if (align_y == "TOP")
-            set_alignment_y(alignment_y::top);
-        else if (align_y == "MIDDLE")
-            set_alignment_y(alignment_y::middle);
-        else if (align_y == "BOTTOM")
-            set_alignment_y(alignment_y::bottom);
-        else {
-            gui::out << gui::warning << node.get_location() << ": "
-                     << "Unknown vertical alignment behavior for " << name_ << ": \"" << align_y
-                     << "\"." << std::endl;
-        }
-    }
+    if (const layout_attribute* attr = node.try_get_attribute("alignX"))
+        set_alignment_x(attr->get_value<alignment_x>());
+    if (const layout_attribute* attr = node.try_get_attribute("alignY"))
+        set_alignment_y(attr->get_value<alignment_y>());
+    if (const layout_attribute* attr = node.try_get_attribute("vertexCacheStrategy"))
+        set_vertex_cache_strategy(attr->get_value<vertex_cache_strategy>());
 }
 
 void font_string::parse_shadow_node_(const layout_node& node) {

--- a/src/gui_font_string_parser.cpp
+++ b/src/gui_font_string_parser.cpp
@@ -27,8 +27,8 @@ void font_string::parse_attributes_(const layout_node& node) {
             get_manager().get_localizer().localize(attr->get_value<std::string>())));
     }
 
-    if (const layout_attribute* attr = node.try_get_attribute("nonspacewrap"))
-        set_non_space_wrap(attr->get_value<bool>());
+    if (const layout_attribute* attr = node.try_get_attribute("nonSpaceWrap"))
+        set_non_space_wrap_enabled(attr->get_value<bool>());
 
     if (const layout_attribute* attr = node.try_get_attribute("spacing"))
         set_spacing(attr->get_value<float>());
@@ -82,7 +82,7 @@ void font_string::parse_attributes_(const layout_node& node) {
 
 void font_string::parse_shadow_node_(const layout_node& node) {
     if (const layout_node* shadow_node = node.try_get_child("Shadow")) {
-        set_shadow(true);
+        enable_shadow();
 
         if (const layout_node* color_node = shadow_node->try_get_child("Color"))
             set_shadow_color(parse_color_node_(*color_node));

--- a/src/gui_frame.cpp
+++ b/src/gui_frame.cpp
@@ -209,10 +209,10 @@ void frame::copy_from(const region& obj) {
     // NB: level is not inherited on purpose; this is difficult to make sense of
     this->set_top_level(frame_obj->is_top_level());
 
-    this->enable_mouse_click(frame_obj->is_mouse_click_enabled());
-    this->enable_mouse_move(frame_obj->is_mouse_move_enabled());
-    this->enable_mouse_wheel(frame_obj->is_mouse_wheel_enabled());
-    this->enable_keyboard(frame_obj->is_keyboard_enabled());
+    this->set_mouse_click_enabled(frame_obj->is_mouse_click_enabled());
+    this->set_mouse_move_enabled(frame_obj->is_mouse_move_enabled());
+    this->set_mouse_wheel_enabled(frame_obj->is_mouse_wheel_enabled());
+    this->set_keyboard_enabled(frame_obj->is_keyboard_enabled());
 
     this->set_movable(frame_obj->is_movable());
     this->set_clamped_to_screen(frame_obj->is_clamped_to_screen());
@@ -432,24 +432,24 @@ void frame::enable_draw_layer(layer layer_id) {
     }
 }
 
-void frame::enable_mouse(bool is_mouse_enabled) {
-    enable_mouse_click(is_mouse_enabled);
-    enable_mouse_move(is_mouse_enabled);
+void frame::set_mouse_enabled(bool is_mouse_enabled) {
+    set_mouse_click_enabled(is_mouse_enabled);
+    set_mouse_move_enabled(is_mouse_enabled);
 }
 
-void frame::enable_mouse_click(bool is_mouse_enabled) {
+void frame::set_mouse_click_enabled(bool is_mouse_enabled) {
     is_mouse_click_enabled_ = is_mouse_enabled;
 }
 
-void frame::enable_mouse_move(bool is_mouse_enabled) {
+void frame::set_mouse_move_enabled(bool is_mouse_enabled) {
     is_mouse_move_enabled_ = is_mouse_enabled;
 }
 
-void frame::enable_mouse_wheel(bool is_mouse_wheel_enabled) {
+void frame::set_mouse_wheel_enabled(bool is_mouse_wheel_enabled) {
     is_mouse_wheel_enabled_ = is_mouse_wheel_enabled;
 }
 
-void frame::enable_keyboard(bool is_keyboard_enabled) {
+void frame::set_keyboard_enabled(bool is_keyboard_enabled) {
     is_keyboard_enabled_ = is_keyboard_enabled;
 }
 

--- a/src/gui_frame_glues.cpp
+++ b/src/gui_frame_glues.cpp
@@ -427,24 +427,24 @@ void frame::register_on_lua(sol::state& lua) {
      */
     type.set_function("get_effective_scale", member_function<&frame::get_effective_scale>());
 
-    /** @function get_frame_level
+    /** @function get_level
      */
-    type.set_function("get_frame_level", member_function<&frame::get_level>());
+    type.set_function("get_level", member_function<&frame::get_level>());
 
-    /** @function get_frame_strata
+    /** @function get_strata
      */
-    type.set_function("get_frame_strata", [](const frame& self) -> sol::optional<std::string> {
-        auto strata_id = self.get_frame_strata();
+    type.set_function("get_strata", [](const frame& self) -> sol::optional<std::string> {
+        auto strata_id = self.get_strata();
         if (strata_id.has_value())
             return utils::to_string(strata_id.value());
         else
             return sol::nullopt;
     });
 
-    /** @function get_frame_strata
+    /** @function get_strata
      */
-    type.set_function("get_effective_frame_strata", [](const frame& self) {
-        return utils::to_string(self.get_effective_frame_strata());
+    type.set_function("get_effective_strata", [](const frame& self) {
+        return utils::to_string(self.get_effective_strata());
     });
 
     /** @function get_hit_rect_insets
@@ -643,21 +643,21 @@ void frame::register_on_lua(sol::state& lua) {
      */
     type.set_function("set_focus", [](frame& self) { self.set_focus(true); });
 
-    /** @function set_frame_level
+    /** @function set_level
      */
-    type.set_function("set_frame_level", member_function<&frame::set_level>());
+    type.set_function("set_level", member_function<&frame::set_level>());
 
-    /** @function set_frame_strata
+    /** @function set_strata
      */
-    type.set_function("set_frame_strata", [](frame& self, sol::optional<std::string> strata_name) {
+    type.set_function("set_strata", [](frame& self, sol::optional<std::string> strata_name) {
         if (!strata_name.has_value()) {
-            self.set_frame_strata(std::nullopt);
+            self.set_strata(std::nullopt);
         } else {
-            if (auto converted = utils::from_string<frame_strata>(strata_name.value());
+            if (auto converted = utils::from_string<strata>(strata_name.value());
                 converted.has_value()) {
-                self.set_frame_strata(converted.value());
+                self.set_strata(converted.value());
             } else {
-                gui::out << gui::warning << "Frame.set_frame_strata: "
+                gui::out << gui::warning << "Frame.set_strata: "
                          << "Unknown strata type: \"" << strata_name.value() << "\"." << std::endl;
             }
         }

--- a/src/gui_frame_glues.cpp
+++ b/src/gui_frame_glues.cpp
@@ -295,6 +295,16 @@ void frame::register_on_lua(sol::state& lua) {
      */
     type.set_function("create_title_region", member_function<&frame::create_title_region>());
 
+    /** @function disable_drag
+     */
+    type.set_function("disable_drag", [](frame& self, sol::optional<std::string> button_name) {
+        if (button_name.has_value()) {
+            self.disable_drag(button_name.value());
+        } else {
+            self.disable_drag();
+        }
+    });
+
     /** @function disable_draw_layer
      */
     type.set_function("disable_draw_layer", [](frame& self, const std::string& layer_name) {
@@ -306,6 +316,43 @@ void frame::register_on_lua(sol::state& lua) {
         }
     });
 
+    /** @function disable_key_capture
+     */
+    type.set_function("disable_key_capture", [](frame& self, sol::optional<std::string> key_name) {
+        if (key_name.has_value()) {
+            self.disable_key_capture(key_name.value());
+        } else {
+            self.disable_key_capture();
+        }
+    });
+
+    /** @function disable_keyboard
+     */
+    type.set_function("disable_keyboard", member_function<&frame::disable_keyboard>());
+
+    /** @function disable_mouse
+     */
+    type.set_function("disable_mouse", member_function<&frame::disable_mouse>());
+
+    /** @function disable_mouse_click
+     */
+    type.set_function("disable_mouse_click", member_function<&frame::disable_mouse_click>());
+
+    /** @function disable_mouse_move
+     */
+    type.set_function("disable_mouse_move", member_function<&frame::disable_mouse_move>());
+
+    /** @function disable_mouse_wheel
+     */
+    type.set_function("disable_mouse_wheel", member_function<&frame::disable_mouse_wheel>());
+
+    /** @function enable_drag
+     */
+    type.set_function(
+        "enable_drag",
+        member_function< // select the right overload for Lua
+            static_cast<void (frame::*)(const std::string&)>(&frame::enable_drag)>());
+
     /** @function enable_draw_layer
      */
     type.set_function("enable_draw_layer", [](frame& self, const std::string& layer_name) {
@@ -316,6 +363,17 @@ void frame::register_on_lua(sol::state& lua) {
                      << "Unknown layer type: \"" << layer_name << "\"." << std::endl;
         }
     });
+
+    /** @function enable_key_capture
+     */
+    type.set_function(
+        "enable_key_capture",
+        member_function< // select the right overload for Lua
+            static_cast<void (frame::*)(const std::string&)>(&frame::enable_key_capture)>());
+
+    /** @function enable_keyboard
+     */
+    type.set_function("enable_keyboard", member_function<&frame::enable_keyboard>());
 
     /** @function enable_mouse
      */
@@ -332,27 +390,6 @@ void frame::register_on_lua(sol::state& lua) {
     /** @function enable_mouse_wheel
      */
     type.set_function("enable_mouse_wheel", member_function<&frame::enable_mouse_wheel>());
-
-    /** @function enable_keyboard
-     */
-    type.set_function("enable_keyboard", member_function<&frame::enable_keyboard>());
-
-    /** @function enable_key_capture
-     */
-    type.set_function(
-        "enable_key_capture",
-        member_function< // select the right overload for Lua
-            static_cast<void (frame::*)(const std::string&)>(&frame::enable_key_capture)>());
-
-    /** @function disable_key_capture
-     */
-    type.set_function("disable_key_capture", [](frame& self, sol::optional<std::string> key_name) {
-        if (key_name.has_value()) {
-            self.disable_key_capture(key_name.value());
-        } else {
-            self.disable_key_capture();
-        }
-    });
 
     /** @function get_backdrop
      */
@@ -555,23 +592,6 @@ void frame::register_on_lua(sol::state& lua) {
      */
     type.set_function("register_event", member_function<&frame::register_event>());
 
-    /** @function enable_drag
-     */
-    type.set_function(
-        "enable_drag",
-        member_function< // select the right overload for Lua
-            static_cast<void (frame::*)(const std::string&)>(&frame::enable_drag)>());
-
-    /** @function disable_drag
-     */
-    type.set_function("disable_drag", [](frame& self, sol::optional<std::string> button_name) {
-        if (button_name.has_value()) {
-            self.disable_drag(button_name.value());
-        } else {
-            self.disable_drag();
-        }
-    });
-
     /** @function set_auto_focus
      */
     type.set_function("set_auto_focus", member_function<&frame::enable_auto_focus>());
@@ -639,13 +659,62 @@ void frame::register_on_lua(sol::state& lua) {
      */
     type.set_function("set_clamped_to_screen", member_function<&frame::set_clamped_to_screen>());
 
+    /** @function set_drag_enabled
+     */
+    type.set_function(
+        "set_drag_enabled",
+        member_function< // select the right overload for Lua
+            static_cast<void (frame::*)(const std::string&, bool)>(&frame::set_drag_enabled)>());
+
+    /** @function set_draw_layer_enabled
+     */
+    type.set_function(
+        "set_draw_layer_enabled", [](frame& self, const std::string& layer_name, bool enable) {
+            if (auto converted = utils::from_string<layer>(layer_name); converted.has_value()) {
+                self.set_draw_layer_enabled(converted.value(), enable);
+            } else {
+                gui::out << gui::warning << "Frame.set_draw_layer_enabled: "
+                         << "Unknown layer type: \"" << layer_name << "\"." << std::endl;
+            }
+        });
+
     /** @function set_focus
      */
     type.set_function("set_focus", [](frame& self) { self.set_focus(true); });
 
+    /** @function set_keyboard_enabled
+     */
+    type.set_function("set_keyboard_enabled", member_function<&frame::set_keyboard_enabled>());
+
+    /** @function set_key_capture_enabled
+     */
+    type.set_function(
+        "set_key_capture_enabled",
+        member_function< // select the right overload for Lua
+            static_cast<void (frame::*)(const std::string&, bool)>(
+                &frame::set_key_capture_enabled)>());
+
     /** @function set_level
      */
     type.set_function("set_level", member_function<&frame::set_level>());
+
+    /** @function set_mouse_wheel_enabled
+     */
+    type.set_function(
+        "set_mouse_wheel_enabled", member_function<&frame::set_mouse_wheel_enabled>());
+
+    /** @function set_mouse_enabled
+     */
+    type.set_function("set_mouse_enabled", member_function<&frame::set_mouse_enabled>());
+
+    /** @function set_mouse_click_enabled
+     */
+    type.set_function(
+        "set_mouse_click_enabled", member_function<&frame::set_mouse_click_enabled>());
+
+    /** @function set_mouse_move_enabled
+     */
+    type.set_function("set_mouse_move_enabled", member_function<&frame::set_mouse_move_enabled>());
 
     /** @function set_strata
      */

--- a/src/gui_frame_glues.cpp
+++ b/src/gui_frame_glues.cpp
@@ -38,13 +38,7 @@
  * when the frame is clicked, which effectively brings the frame to the
  * front.
  *
- * __Children and regions.__ When a frame is hidden, all its children
- * and regions will also be hidden. Likewise, deleting a frame will
- * automatically delete all its children and regions, unless they are
- * detached first. Other than this, children and regions do not need to
- * be located inside the frame; this is controlled purely by their anchors.
- * Therefore, if a child is not anchored to its parent, moving the parent
- * will not automatically move the child.
+ * __Children and layered regions.__ See the @{Region} documentation.
  *
  * __Events.__ Frames can react to events. For this to happen, a callback
  * function must be registered to handle the corresponding event. There are
@@ -125,7 +119,7 @@
  * keyboard-enabled frame is focused, only the topmost frame with
  * @{Frame:enable_key_capture} will receive the event. If no frame has
  * captured the key, then the key is tested for existing key bindings (see
- * @{Manager.register_key_binding}). This event provides five arguments to the registered
+ * @{GUI.register_key_binding}). This event provides five arguments to the registered
  * callback: a number identifying the main key being pressed, three boolean flags
  * for "Shift", "Ctrl", and "Alt, and finally the human-readable name of the
  * key combination being pressed (e.g., Shift+A).

--- a/src/gui_frame_glues.cpp
+++ b/src/gui_frame_glues.cpp
@@ -536,6 +536,10 @@ void frame::register_on_lua(sol::state& lua) {
         member_function< // select the right overload for Lua
             static_cast<utils::observer_ptr<region> (frame::*)()>(&frame::get_title_region)>());
 
+    /** @function get_update_rate
+     */
+    type.set_function("get_update_rate", member_function<&frame::get_update_rate>());
+
     /** @function has_script
      */
     type.set_function("has_script", member_function<&frame::has_script>());
@@ -793,6 +797,10 @@ void frame::register_on_lua(sol::state& lua) {
     /** @function set_top_level
      */
     type.set_function("set_top_level", member_function<&frame::set_top_level>());
+
+    /** @function set_update_rate
+     */
+    type.set_function("set_update_rate", member_function<&frame::set_update_rate>());
 
     /** @function set_user_placed
      */

--- a/src/gui_frame_glues.cpp
+++ b/src/gui_frame_glues.cpp
@@ -222,7 +222,7 @@ namespace lxgui::gui {
 
 void frame::register_on_lua(sol::state& lua) {
     auto type = lua.new_usertype<frame>(
-        "Frame", sol::base_classes, sol::bases<region>(), sol::meta_function::index,
+        frame::class_name, sol::base_classes, sol::bases<region>(), sol::meta_function::index,
         member_function<&frame::get_lua_member_>(), sol::meta_function::new_index,
         member_function<&frame::set_lua_member_>());
 

--- a/src/gui_frame_parser.cpp
+++ b/src/gui_frame_parser.cpp
@@ -44,17 +44,17 @@ void frame::parse_attributes_(const layout_node& node) {
         set_movable(attr->get_value<bool>());
     if (const layout_attribute* attr = node.try_get_attribute("resizable"))
         set_resizable(attr->get_value<bool>());
-    if (const layout_attribute* attr = node.try_get_attribute("frameStrata"))
-        set_frame_strata(attr->get_value<frame_strata>());
+    if (const layout_attribute* attr = node.try_get_attribute("strata"))
+        set_strata(attr->get_value<strata>());
 
-    if (const layout_attribute* attr = node.try_get_attribute("frameLevel")) {
+    if (const layout_attribute* attr = node.try_get_attribute("level")) {
         if (!is_virtual_) {
-            std::string frame_level = attr->get_value<std::string>();
-            if (frame_level != "PARENT")
+            std::string level = attr->get_value<std::string>();
+            if (level != "PARENT")
                 set_level(attr->get_value<int>());
         } else {
             gui::out << gui::warning << node.get_location() << ": "
-                     << "\"frameLevel\" is not allowed for virtual regions. Ignored." << std::endl;
+                     << "\"level\" is not allowed for virtual regions. Ignored." << std::endl;
         }
     }
 

--- a/src/gui_frame_parser.cpp
+++ b/src/gui_frame_parser.cpp
@@ -72,6 +72,8 @@ void frame::parse_attributes_(const layout_node& node) {
         set_clamped_to_screen(attr->get_value<bool>());
     if (const layout_attribute* attr = node.try_get_attribute("autoFocus"))
         enable_auto_focus(attr->get_value<bool>());
+    if (const layout_attribute* attr = node.try_get_attribute("updateRate"))
+        set_update_rate(attr->get_value<float>());
 }
 
 void frame::parse_resize_bounds_node_(const layout_node& node) {

--- a/src/gui_frame_parser.cpp
+++ b/src/gui_frame_parser.cpp
@@ -59,15 +59,15 @@ void frame::parse_attributes_(const layout_node& node) {
     }
 
     if (const layout_attribute* attr = node.try_get_attribute("enableMouse"))
-        enable_mouse(attr->get_value<bool>());
+        set_mouse_enabled(attr->get_value<bool>());
     if (const layout_attribute* attr = node.try_get_attribute("enableMouseMove"))
-        enable_mouse_move(attr->get_value<bool>());
+        set_mouse_move_enabled(attr->get_value<bool>());
     if (const layout_attribute* attr = node.try_get_attribute("enableMouseClick"))
-        enable_mouse_click(attr->get_value<bool>());
+        set_mouse_click_enabled(attr->get_value<bool>());
     if (const layout_attribute* attr = node.try_get_attribute("enableMouseWheel"))
-        enable_mouse_wheel(attr->get_value<bool>());
+        set_mouse_wheel_enabled(attr->get_value<bool>());
     if (const layout_attribute* attr = node.try_get_attribute("enableKeyboard"))
-        enable_keyboard(attr->get_value<bool>());
+        set_keyboard_enabled(attr->get_value<bool>());
     if (const layout_attribute* attr = node.try_get_attribute("clampedToScreen"))
         set_clamped_to_screen(attr->get_value<bool>());
     if (const layout_attribute* attr = node.try_get_attribute("autoFocus"))

--- a/src/gui_frame_renderer.cpp
+++ b/src/gui_frame_renderer.cpp
@@ -12,7 +12,7 @@ void check_sorted(const T& list) {
     gui::out << "----------" << std::endl;
     for (auto iter = list.begin(); iter != list.end(); ++iter) {
         gui::out << " - " << (*iter)->get_name() << ": "
-                 << utils::to_string((*iter)->get_effective_frame_strata()) << ", "
+                 << utils::to_string((*iter)->get_effective_strata()) << ", "
                  << (*iter)->get_level() << std::endl;
 
         if (iter != list.begin()) {
@@ -28,30 +28,30 @@ void check_sorted(const T& list) {
 }
 
 struct strata_comparator {
-    bool operator()(frame_strata s1, frame_strata s2) const {
-        using int_type        = std::underlying_type_t<frame_strata>;
+    bool operator()(strata s1, strata s2) const {
+        using int_type        = std::underlying_type_t<strata>;
         const auto strata_id1 = static_cast<int_type>(s1);
         const auto strata_id2 = static_cast<int_type>(s2);
         return strata_id1 < strata_id2;
     }
 
-    bool operator()(const frame* f1, frame_strata s2) const {
-        return operator()(f1->get_effective_frame_strata(), s2);
+    bool operator()(const frame* f1, strata s2) const {
+        return operator()(f1->get_effective_strata(), s2);
     }
 
-    bool operator()(frame_strata s1, const frame* f2) const {
-        return operator()(s1, f2->get_effective_frame_strata());
+    bool operator()(strata s1, const frame* f2) const {
+        return operator()(s1, f2->get_effective_strata());
     }
 
     bool operator()(const frame* f1, const frame* f2) const {
-        return operator()(f1->get_effective_frame_strata(), f2->get_effective_frame_strata());
+        return operator()(f1->get_effective_strata(), f2->get_effective_strata());
     }
 };
 
 bool frame_renderer::frame_comparator::operator()(const frame* f1, const frame* f2) const {
-    using int_type        = std::underlying_type_t<frame_strata>;
-    const auto strata_id1 = static_cast<int_type>(f1->get_effective_frame_strata());
-    const auto strata_id2 = static_cast<int_type>(f2->get_effective_frame_strata());
+    using int_type        = std::underlying_type_t<strata>;
+    const auto strata_id1 = static_cast<int_type>(f1->get_effective_strata());
+    const auto strata_id2 = static_cast<int_type>(f2->get_effective_strata());
 
     if (strata_id1 < strata_id2)
         return true;
@@ -71,15 +71,15 @@ bool frame_renderer::frame_comparator::operator()(const frame* f1, const frame* 
 
 frame_renderer::frame_renderer() {
     for (std::size_t i = 0; i < strata_list_.size(); ++i) {
-        strata_list_[i].id = static_cast<frame_strata>(i);
+        strata_list_[i].id = static_cast<strata>(i);
     }
 }
 
-void frame_renderer::notify_strata_needs_redraw_(strata& strata) {
-    strata.redraw_flag = true;
+void frame_renderer::notify_strata_needs_redraw_(strata_data& strata_obj) {
+    strata_obj.redraw_flag = true;
 }
 
-void frame_renderer::notify_strata_needs_redraw(frame_strata strata_id) {
+void frame_renderer::notify_strata_needs_redraw(strata strata_id) {
     notify_strata_needs_redraw_(strata_list_[static_cast<std::size_t>(strata_id)]);
 }
 
@@ -102,26 +102,24 @@ void frame_renderer::notify_rendered_frame(const utils::observer_ptr<frame>& obj
     }
 
     for (std::size_t i = 0; i < strata_list_.size(); ++i) {
-        strata_list_[i].range = get_strata_range_(static_cast<frame_strata>(i));
+        strata_list_[i].range = get_strata_range_(static_cast<strata>(i));
     }
 
-    const auto frame_strata = obj->get_effective_frame_strata();
-    auto&      strata       = strata_list_[static_cast<std::size_t>(frame_strata)];
+    const auto strata_id  = obj->get_effective_strata();
+    auto&      strata_obj = strata_list_[static_cast<std::size_t>(strata_id)];
 
     frame_list_updated_ = true;
-    notify_strata_needs_redraw_(strata);
+    notify_strata_needs_redraw_(strata_obj);
 }
 
-void frame_renderer::notify_frame_strata_changed(
-    const utils::observer_ptr<frame>& /*obj*/,
-    frame_strata old_strata_id,
-    frame_strata new_strata_id) {
+void frame_renderer::notify_strata_changed(
+    const utils::observer_ptr<frame>& /*obj*/, strata old_strata_id, strata new_strata_id) {
 
     std::stable_sort(
         sorted_frame_list_.begin(), sorted_frame_list_.end(), sorted_frame_list_.comparator());
 
     for (std::size_t i = 0; i < strata_list_.size(); ++i) {
-        strata_list_[i].range = get_strata_range_(static_cast<frame_strata>(i));
+        strata_list_[i].range = get_strata_range_(static_cast<strata>(i));
     }
 
     auto& old_strata = strata_list_[static_cast<std::size_t>(old_strata_id)];
@@ -132,18 +130,17 @@ void frame_renderer::notify_frame_strata_changed(
     notify_strata_needs_redraw_(new_strata);
 }
 
-std::pair<std::size_t, std::size_t>
-frame_renderer::get_strata_range_(frame_strata strata_id) const {
+std::pair<std::size_t, std::size_t> frame_renderer::get_strata_range_(strata strata_id) const {
     auto range = std::equal_range(
         sorted_frame_list_.begin(), sorted_frame_list_.end(), strata_id, strata_comparator{});
 
     return {range.first - sorted_frame_list_.begin(), range.second - sorted_frame_list_.begin()};
 }
 
-void frame_renderer::notify_frame_level_changed(
+void frame_renderer::notify_level_changed(
     const utils::observer_ptr<frame>& obj, int /*old_level*/, int /*new_level*/) {
 
-    const auto strata_id = obj->get_effective_frame_strata();
+    const auto strata_id = obj->get_effective_strata();
 
     auto& strata_obj = strata_list_[static_cast<std::size_t>(strata_id)];
 
@@ -169,7 +166,7 @@ frame_renderer::find_topmost_frame(const std::function<bool(const frame&)>& pred
     return nullptr;
 }
 
-int frame_renderer::get_highest_level(frame_strata strata_id) const {
+int frame_renderer::get_highest_level(strata strata_id) const {
     auto range = strata_list_[static_cast<std::size_t>(strata_id)].range;
     auto begin = sorted_frame_list_.begin() + range.first;
     auto last  = sorted_frame_list_.begin() + range.second;
@@ -182,7 +179,7 @@ int frame_renderer::get_highest_level(frame_strata strata_id) const {
     return 0;
 }
 
-void frame_renderer::render_strata_(const strata& strata_obj) const {
+void frame_renderer::render_strata_(const strata_data& strata_obj) const {
     auto begin = sorted_frame_list_.begin() + strata_obj.range.first;
     auto end   = sorted_frame_list_.begin() + strata_obj.range.second;
 

--- a/src/gui_layered_region_glues.cpp
+++ b/src/gui_layered_region_glues.cpp
@@ -24,9 +24,9 @@ namespace lxgui::gui {
 
 void layered_region::register_on_lua(sol::state& lua) {
     auto type = lua.new_usertype<layered_region>(
-        "LayeredRegion", sol::base_classes, sol::bases<region>(), sol::meta_function::index,
-        member_function<&layered_region::get_lua_member_>(), sol::meta_function::new_index,
-        member_function<&layered_region::set_lua_member_>());
+        layered_region::class_name, sol::base_classes, sol::bases<region>(),
+        sol::meta_function::index, member_function<&layered_region::get_lua_member_>(),
+        sol::meta_function::new_index, member_function<&layered_region::set_lua_member_>());
 
     /** @function set_draw_layer
      */

--- a/src/gui_localizer_glues.cpp
+++ b/src/gui_localizer_glues.cpp
@@ -86,7 +86,7 @@
 * The translation must then refer to these dynamic elements to include them in the
 * displayed test. Dynamic elements are always indicated with pairs of braces `{}`.
 * Inside the braces, you can supply additional modifiers which will affect how the
-* data is being displayed. This follows the [&](https://fmt.dev/latest/syntax.html)
+* data is being displayed. This follows the [fmtlib](https://fmt.dev/latest/syntax.html)
 * syntax. For example, the message above can be represented with the string
 *
 *     ["player_lost_hp"] = "{} has lost {} HP.",
@@ -152,7 +152,7 @@
 *         end
 *     end,
 *
-* This can be used to implement complex support language rules like adding an "s" to
+* This can be used to implement complex language rules like adding an "s" to
 * plurals of nouns in French:
 *
 *     -- Table for plurals that are not obtained by just adding "s"
@@ -240,7 +240,7 @@ void localizer::register_on_lua(sol::state& lua) {
      * main language, and `{REGION}` is a two-letter upper case word identifying the dialect or
      * regional variant of the language (e.g., "enUS" for United States of America English, and
      * "enGB" for Great Britain English). This change will not take effect until the GUI is
-     * re-loaded, see @{Manager.reload_ui}.
+     * re-loaded, see @{GUI.reload_ui}.
      * @function set_preferred_languages
      * @tparam table languages A table listing the languages to use to display the GUI
      */
@@ -251,13 +251,13 @@ void localizer::register_on_lua(sol::state& lua) {
      * After calling this function, it is highly recommended to always include at least
      * the Unicode groups "basic latin" (to render basic ASCII characters) and
      * "geometric shapes" (to render the "missing character" glyph).
-     * This change will not take effect until the GUI is re-loaded, see @{Manager.reload_ui}.
+     * This change will not take effect until the GUI is re-loaded, see @{GUI.reload_ui}.
      * @function clear_allowed_code_points
      */
     lua.set_function("clear_allowed_code_points", [&]() { clear_allowed_code_points(); });
 
     /** Adds a new range to the set of allowed code points.
-     * This change will not take effect until the GUI is re-loaded, see @{Manager.reload_ui}.
+     * This change will not take effect until the GUI is re-loaded, see @{GUI.reload_ui}.
      * @tparam integer first The first code point in the range
      * @tparam integer last The last code point in the range
      * @function add_allowed_code_points
@@ -271,7 +271,7 @@ void localizer::register_on_lua(sol::state& lua) {
      * ranges of Unicode code points that are typically associated to a language
      * or a group of languages. This function knows about such groups and the
      * ranges of code point they correspond to, and is therefore more user-friendly.
-     * This change will not take effect until the GUI is re-loaded, see @{Manager.reload_ui}.
+     * This change will not take effect until the GUI is re-loaded, see @{GUI.reload_ui}.
      * @tparam string group The name of the Unicode code group to allow
      * @function add_allowed_code_points_for_group
      */
@@ -283,7 +283,7 @@ void localizer::register_on_lua(sol::state& lua) {
      * Language codes are based on the ISO-639-1 standard, or later standards for those
      * languages which were not listed in ISO-639-1. They are always in lower case, and
      * typically composed of just two letters, but sometimes more.
-     * This change will not take effect until the GUI is re-loaded, see @{Manager.reload_ui}.
+     * This change will not take effect until the GUI is re-loaded, see @{GUI.reload_ui}.
      * @tparam string language The language code (e.g., "en", "ru", etc.)
      * @function add_allowed_code_points_for_language
      */
@@ -294,7 +294,7 @@ void localizer::register_on_lua(sol::state& lua) {
     /** Attempts to automatically detect the set of allowed code points based on preferred
      * languages. Only use it if you need to reset the allowed code points to the default after
      * changing the preferred languages with @{set_preferred_languages}. This change will not take
-     * effect until the GUI is re-loaded, see @{Manager.reload_ui}.
+     * effect until the GUI is re-loaded, see @{GUI.reload_ui}.
      * @function auto_detect_allowed_code_points
      */
     lua.set_function(

--- a/src/gui_manager_glues.cpp
+++ b/src/gui_manager_glues.cpp
@@ -21,7 +21,7 @@
  * for creating or destroying @{Frame}s, and accessing a few
  * other global properties or objects.
  *
- * @module Manager
+ * @module GUI
  */
 
 namespace lxgui::gui {

--- a/src/gui_region_glues.cpp
+++ b/src/gui_region_glues.cpp
@@ -33,26 +33,33 @@
  * Note: Although you can destroy this Lua variable by setting it to nil, this is
  * not recommended: the object will _not_ be destroyed (nor garbage-collected)
  * because it still exists in the C++ memory space. The only way to truly destroy
- * an object is to call @{Manager.delete_frame} (for @{Frame}s only). Destroying and
+ * an object is to call @{GUI.delete_frame} (for @{Frame}s only). Destroying and
  * creating objects has a cost however. If the object is likely to reappear later
  * with the same content, simply hide it and show it again later on. If the
  * content may change, you can also recycle the object, i.e., keep it alive and
  * simply change its content when it later reappears.
  *
  * __Parent-child relationship.__ Parents of @{Region}s are @{Frame}s. See
- * the @{Frame} class documentation for more information. One important aspect
- * of the parent-child relationship is related to the object name. If a
- * @{Region} has a parent, it can be given a name starting with `"$parent"`.
+ * the @{Frame} class documentation for more information. One important
+ * aspect of the parent-child relationship is related to the object name. If a
+ * region has a parent, it can be given a name starting with `"$parent"`.
  * The name of the parent will automatically replace the `"$parent"` string.
  * For example, if an object is named `"$parentButton"` and its parent is named
  * `"ErrorMessage"`, the final name of the object will be `"ErrorMessageButton"`.
  * It can be accessed from the Lua state as `ErrorMessageButton`, or as
- * `ErrorMessage.Button`. Note that this is totally dynamic: if you later change
- * the parent of this button to be another frame, for example `"ExitDialog"`
- * its name will naturally change to `"ExitDialogButton"`, and it can be accessed
- * from Lua as `ExitDialogButton`, or as `ExitDialog.Button`. This is particularly
- * powerful for writing generic code which does not rely on the full names of
- * objects, only on their child-parent relationship.
+ * `ErrorMessage.Button`. This is particularly important when using inheritance,
+ * as the final name of an inherited child region then naturally depends on the
+ * name of its parent.
+ *
+ * A child will inherit some properties from its parent: transparency, scaling,
+ * visibility (show/hide), strata (if not explicitly specified), level
+ * (incremented from its parent's), and renderer (if not explicitly specified).
+ * Note in particular that the parent-child relationship does not impose any
+ * link between the child and its parent's position and size: this must be done
+ * explicitly with anchors, as required.
+ *
+ * Lastly, a child is *owned* by its parent: if the parent is destroyed, the
+ * child will be destroyed as well.
  *
  * __Positioning.__ @{Region}s have a position on the screen, but this is
  * not parametrized as a simple pair of X and Y coordinates. Instead, objects

--- a/src/gui_region_glues.cpp
+++ b/src/gui_region_glues.cpp
@@ -155,7 +155,7 @@ sol::object region::get_lua_member_(const std::string& key) const {
 
 void region::register_on_lua(sol::state& lua) {
     auto type = lua.new_usertype<region>(
-        "Region", sol::meta_function::index, member_function<&region::get_lua_member_>(),
+        region::class_name, sol::meta_function::index, member_function<&region::get_lua_member_>(),
         sol::meta_function::new_index, member_function<&region::set_lua_member_>());
 
     /** @function get_alpha

--- a/src/gui_renderer.cpp
+++ b/src/gui_renderer.cpp
@@ -93,8 +93,9 @@ void renderer::render_quads(
 
     if (!is_quad_batching_enabled()) {
         // Render immediately
-        vertex_count_ += quad_list.size() * 4;
+        vertex_count_ += quad_list.size() * 6;
         render_quads_(mat, quad_list);
+        ++batch_count_;
         return;
     }
 
@@ -137,7 +138,7 @@ void renderer::flush_quad_batch() {
     if (cache.data.empty())
         return;
 
-    vertex_count_ += cache.data.size() * 4;
+    vertex_count_ += cache.data.size() * 6;
 
     if (cache.cache) {
         cache.cache->update(cache.data[0].data(), cache.data.size() * 4);
@@ -162,9 +163,11 @@ void renderer::render_cache(
         flush_quad_batch();
     }
 
-    vertex_count_ += cache.get_vertex_count() * 4;
+    vertex_count_ += cache.get_vertex_count();
 
     render_cache_(mat, cache, model_transform);
+
+    ++batch_count_;
 }
 
 bool renderer::is_quad_batching_enabled() const {

--- a/src/gui_root.cpp
+++ b/src/gui_root.cpp
@@ -120,7 +120,7 @@ void root::create_caching_render_target_() {
     screen_quad_.v[3].uvs = screen_quad_.mat->get_canvas_uv(vector2f(0, 1), true);
 }
 
-void root::create_strata_cache_render_target_(strata& strata_obj) {
+void root::create_strata_cache_render_target_(strata_data& strata_obj) {
     if (strata_obj.target)
         strata_obj.target->set_dimensions(screen_dimensions_);
     else

--- a/src/gui_scroll_frame.cpp
+++ b/src/gui_scroll_frame.cpp
@@ -167,13 +167,13 @@ float scroll_frame::get_vertical_scroll_range() const {
     return scroll_range_.y;
 }
 
-void scroll_frame::update(float delta) {
+void scroll_frame::update_(float delta) {
     vector2f old_child_size;
     if (scroll_child_)
         old_child_size = scroll_child_->get_apparent_dimensions();
 
     alive_checker checker(*this);
-    base::update(delta);
+    base::update_(delta);
     if (!checker.is_alive())
         return;
 

--- a/src/gui_scroll_frame.cpp
+++ b/src/gui_scroll_frame.cpp
@@ -272,7 +272,7 @@ scroll_frame::find_topmost_frame(const std::function<bool(const frame&)>& predic
     return nullptr;
 }
 
-void scroll_frame::notify_strata_needs_redraw(frame_strata strata_id) {
+void scroll_frame::notify_strata_needs_redraw(strata strata_id) {
     frame_renderer::notify_strata_needs_redraw(strata_id);
 
     redraw_scroll_render_target_flag_ = true;

--- a/src/gui_scroll_frame_glues.cpp
+++ b/src/gui_scroll_frame_glues.cpp
@@ -37,9 +37,9 @@ namespace lxgui::gui {
 
 void scroll_frame::register_on_lua(sol::state& lua) {
     auto type = lua.new_usertype<scroll_frame>(
-        "ScrollFrame", sol::base_classes, sol::bases<region, frame>(), sol::meta_function::index,
-        member_function<&scroll_frame::get_lua_member_>(), sol::meta_function::new_index,
-        member_function<&scroll_frame::set_lua_member_>());
+        scroll_frame::class_name, sol::base_classes, sol::bases<region, frame>(),
+        sol::meta_function::index, member_function<&scroll_frame::get_lua_member_>(),
+        sol::meta_function::new_index, member_function<&scroll_frame::set_lua_member_>());
 
     /** @function get_horizontal_scroll
      */

--- a/src/gui_slider.cpp
+++ b/src/gui_slider.cpp
@@ -24,7 +24,7 @@ slider::slider(utils::control_block& block, manager& mgr, const frame_core_attri
 
     initialize_(*this, attr);
 
-    enable_mouse(true);
+    enable_mouse();
     enable_drag(input::mouse_button::left);
 }
 

--- a/src/gui_slider_glues.cpp
+++ b/src/gui_slider_glues.cpp
@@ -31,9 +31,9 @@ namespace lxgui::gui {
 
 void slider::register_on_lua(sol::state& lua) {
     auto type = lua.new_usertype<slider>(
-        "Slider", sol::base_classes, sol::bases<region, frame>(), sol::meta_function::index,
-        member_function<&slider::get_lua_member_>(), sol::meta_function::new_index,
-        member_function<&slider::set_lua_member_>());
+        slider::class_name, sol::base_classes, sol::bases<region, frame>(),
+        sol::meta_function::index, member_function<&slider::get_lua_member_>(),
+        sol::meta_function::new_index, member_function<&slider::set_lua_member_>());
 
     /** @function allow_clicks_outside_thumb
      */

--- a/src/gui_status_bar_glues.cpp
+++ b/src/gui_status_bar_glues.cpp
@@ -32,9 +32,9 @@ namespace lxgui::gui {
 
 void status_bar::register_on_lua(sol::state& lua) {
     auto type = lua.new_usertype<status_bar>(
-        "StatusBar", sol::base_classes, sol::bases<region, frame>(), sol::meta_function::index,
-        member_function<&status_bar::get_lua_member_>(), sol::meta_function::new_index,
-        member_function<&status_bar::set_lua_member_>());
+        status_bar::class_name, sol::base_classes, sol::bases<region, frame>(),
+        sol::meta_function::index, member_function<&status_bar::get_lua_member_>(),
+        sol::meta_function::new_index, member_function<&status_bar::set_lua_member_>());
 
     /** @function get_min_max_values
      */

--- a/src/gui_text.cpp
+++ b/src/gui_text.cpp
@@ -498,12 +498,11 @@ bool text::get_remove_starting_spaces() const {
     return remove_starting_spaces_;
 }
 
-void text::enable_word_wrap(bool wrap, bool add_ellipsis) {
-    if (word_wrap_enabled_ == wrap && ellipsis_enabled_ == add_ellipsis)
+void text::set_word_wrap_enabled(bool wrap) {
+    if (word_wrap_enabled_ == wrap)
         return;
 
     word_wrap_enabled_ = wrap;
-    ellipsis_enabled_  = add_ellipsis;
     notify_cache_dirty_();
 }
 
@@ -511,7 +510,19 @@ bool text::is_word_wrap_enabled() const {
     return word_wrap_enabled_;
 }
 
-void text::enable_formatting(bool formatting) {
+void text::set_word_ellipsis_enabled(bool add_ellipsis) {
+    if (ellipsis_enabled_ == add_ellipsis)
+        return;
+
+    ellipsis_enabled_ = add_ellipsis;
+    notify_cache_dirty_();
+}
+
+bool text::is_word_ellipsis_enabled() const {
+    return ellipsis_enabled_;
+}
+
+void text::set_formatting_enabled(bool formatting) {
     if (formatting == formatting_enabled_)
         return;
 

--- a/src/gui_texture_glues.cpp
+++ b/src/gui_texture_glues.cpp
@@ -30,7 +30,7 @@ std::optional<orientation> get_gradient_orientation(const std::string& orientati
 
 void texture::register_on_lua(sol::state& lua) {
     auto type = lua.new_usertype<texture>(
-        "Texture", sol::base_classes, sol::bases<region, layered_region>(),
+        texture::class_name, sol::base_classes, sol::bases<region, layered_region>(),
         sol::meta_function::index, member_function<&texture::get_lua_member_>(),
         sol::meta_function::new_index, member_function<&texture::set_lua_member_>());
 

--- a/src/utils_string.cpp
+++ b/src/utils_string.cpp
@@ -184,9 +184,9 @@ std::size_t hex_to_uint(string_view s) {
 namespace impl {
 
 template<typename T>
-std::optional<T> from_string_template(string_view s) {
+std::optional<T> from_string_template(const std::locale& loc, string_view s) {
     std::istringstream ss{std::string(s)};
-    ss.imbue(std::locale::classic());
+    ss.imbue(loc);
 
     T v;
     ss >> v;
@@ -205,44 +205,137 @@ std::optional<T> from_string_template(string_view s) {
     return {};
 }
 
+template<typename T>
+std::optional<T> from_string_template(const std::locale& loc, ustring_view s) {
+    return from_string_template<T>(loc, unicode_to_utf8(s));
+}
+
+// ----- locale, utf8 string
+
+template<>
+std::optional<int> from_string<int>(const std::locale& loc, string_view s) {
+    return from_string_template<int>(loc, s);
+}
+
+template<>
+std::optional<long> from_string<long>(const std::locale& loc, string_view s) {
+    return from_string_template<long>(loc, s);
+}
+
+template<>
+std::optional<long long> from_string<long long>(const std::locale& loc, string_view s) {
+    return from_string_template<long long>(loc, s);
+}
+
+template<>
+std::optional<unsigned> from_string<unsigned>(const std::locale& loc, string_view s) {
+    return from_string_template<unsigned>(loc, s);
+}
+
+template<>
+std::optional<unsigned long> from_string<unsigned long>(const std::locale& loc, string_view s) {
+    return from_string_template<unsigned long>(loc, s);
+}
+
+template<>
+std::optional<unsigned long long>
+from_string<unsigned long long>(const std::locale& loc, string_view s) {
+    return from_string_template<unsigned long long>(loc, s);
+}
+
+template<>
+std::optional<float> from_string<float>(const std::locale& loc, string_view s) {
+    return from_string_template<float>(loc, s);
+}
+
+template<>
+std::optional<double> from_string<double>(const std::locale& loc, string_view s) {
+    return from_string_template<double>(loc, s);
+}
+
+// ----- locale, utf32 string
+
+template<>
+std::optional<int> from_string<int>(const std::locale& loc, ustring_view s) {
+    return from_string_template<int>(loc, s);
+}
+
+template<>
+std::optional<long> from_string<long>(const std::locale& loc, ustring_view s) {
+    return from_string_template<long>(loc, s);
+}
+
+template<>
+std::optional<long long> from_string<long long>(const std::locale& loc, ustring_view s) {
+    return from_string_template<long long>(loc, s);
+}
+
+template<>
+std::optional<unsigned> from_string<unsigned>(const std::locale& loc, ustring_view s) {
+    return from_string_template<unsigned>(loc, s);
+}
+
+template<>
+std::optional<unsigned long> from_string<unsigned long>(const std::locale& loc, ustring_view s) {
+    return from_string_template<unsigned long>(loc, s);
+}
+
+template<>
+std::optional<unsigned long long>
+from_string<unsigned long long>(const std::locale& loc, ustring_view s) {
+    return from_string_template<unsigned long long>(loc, s);
+}
+
+template<>
+std::optional<float> from_string<float>(const std::locale& loc, ustring_view s) {
+    return from_string_template<float>(loc, s);
+}
+
+template<>
+std::optional<double> from_string<double>(const std::locale& loc, ustring_view s) {
+    return from_string_template<double>(loc, s);
+}
+
+// ----- C locale, utf8 string
+
 template<>
 std::optional<int> from_string<int>(string_view s) {
-    return from_string_template<int>(s);
+    return from_string_template<int>(std::locale::classic(), s);
 }
 
 template<>
 std::optional<long> from_string<long>(string_view s) {
-    return from_string_template<long>(s);
+    return from_string_template<long>(std::locale::classic(), s);
 }
 
 template<>
 std::optional<long long> from_string<long long>(string_view s) {
-    return from_string_template<long long>(s);
+    return from_string_template<long long>(std::locale::classic(), s);
 }
 
 template<>
 std::optional<unsigned> from_string<unsigned>(string_view s) {
-    return from_string_template<unsigned>(s);
+    return from_string_template<unsigned>(std::locale::classic(), s);
 }
 
 template<>
 std::optional<unsigned long> from_string<unsigned long>(string_view s) {
-    return from_string_template<unsigned long>(s);
+    return from_string_template<unsigned long>(std::locale::classic(), s);
 }
 
 template<>
 std::optional<unsigned long long> from_string<unsigned long long>(string_view s) {
-    return from_string_template<unsigned long long>(s);
+    return from_string_template<unsigned long long>(std::locale::classic(), s);
 }
 
 template<>
 std::optional<float> from_string<float>(string_view s) {
-    return from_string_template<float>(s);
+    return from_string_template<float>(std::locale::classic(), s);
 }
 
 template<>
 std::optional<double> from_string<double>(string_view s) {
-    return from_string_template<double>(s);
+    return from_string_template<double>(std::locale::classic(), s);
 }
 
 template<>
@@ -259,49 +352,46 @@ std::optional<string> from_string<string>(string_view s) {
     return string{s};
 }
 
-template<typename T>
-std::optional<T> from_string_template(ustring_view s) {
-    return from_string<T>(unicode_to_utf8(s));
-}
+// ----- C locale, utf32 string
 
 template<>
 std::optional<int> from_string<int>(ustring_view s) {
-    return from_string_template<int>(s);
+    return from_string_template<int>(std::locale::classic(), s);
 }
 
 template<>
 std::optional<long> from_string<long>(ustring_view s) {
-    return from_string_template<long>(s);
+    return from_string_template<long>(std::locale::classic(), s);
 }
 
 template<>
 std::optional<long long> from_string<long long>(ustring_view s) {
-    return from_string_template<long long>(s);
+    return from_string_template<long long>(std::locale::classic(), s);
 }
 
 template<>
 std::optional<unsigned> from_string<unsigned>(ustring_view s) {
-    return from_string_template<unsigned>(s);
+    return from_string_template<unsigned>(std::locale::classic(), s);
 }
 
 template<>
 std::optional<unsigned long> from_string<unsigned long>(ustring_view s) {
-    return from_string_template<unsigned long>(s);
+    return from_string_template<unsigned long>(std::locale::classic(), s);
 }
 
 template<>
 std::optional<unsigned long long> from_string<unsigned long long>(ustring_view s) {
-    return from_string_template<unsigned long long>(s);
+    return from_string_template<unsigned long long>(std::locale::classic(), s);
 }
 
 template<>
 std::optional<float> from_string<float>(ustring_view s) {
-    return from_string_template<float>(s);
+    return from_string_template<float>(std::locale::classic(), s);
 }
 
 template<>
 std::optional<double> from_string<double>(ustring_view s) {
-    return from_string_template<double>(s);
+    return from_string_template<double>(std::locale::classic(), s);
 }
 
 template<>
@@ -320,18 +410,36 @@ std::optional<ustring> from_string<ustring>(ustring_view s) {
 
 } // namespace impl
 
+bool is_number(const std::locale& loc, string_view s) {
+    return impl::from_string<double>(loc, s).has_value();
+}
+
+bool is_number(const std::locale& loc, ustring_view s) {
+    return impl::from_string<double>(loc, s).has_value();
+}
+
+bool is_integer(const std::locale& loc, string_view s) {
+    return impl::from_string<std::int64_t>(loc, s).has_value();
+}
+
+bool is_integer(const std::locale& loc, ustring_view s) {
+    return impl::from_string<std::int64_t>(loc, s).has_value();
+}
+
 bool is_number(string_view s) {
-    std::istringstream temp{std::string(s)};
-    temp.imbue(std::locale::classic());
-
-    double value = 0;
-    temp >> value;
-
-    return !temp.fail();
+    return is_number(std::locale::classic(), s);
 }
 
 bool is_number(ustring_view s) {
-    return is_number(unicode_to_utf8(s));
+    return is_number(std::locale::classic(), s);
+}
+
+bool is_integer(string_view s) {
+    return is_integer(std::locale::classic(), s);
+}
+
+bool is_integer(ustring_view s) {
+    return is_integer(std::locale::classic(), s);
 }
 
 bool is_number(char s) {
@@ -340,20 +448,6 @@ bool is_number(char s) {
 
 bool is_number(char32_t s) {
     return U'0' <= s && s <= U'9';
-}
-
-bool is_integer(string_view s) {
-    std::istringstream temp{std::string(s)};
-    temp.imbue(std::locale::classic());
-
-    std::int64_t value = 0;
-    temp >> value;
-
-    return !temp.fail();
-}
-
-bool is_integer(ustring_view s) {
-    return is_integer(unicode_to_utf8(s));
 }
 
 bool is_integer(char s) {


### PR DESCRIPTION
 - Updated the parent-child documentation in Doxygen and LuaDoc
 - Renamed the LuaDoc module "Manager" to "GUI"
 - Renamed "frame_strata" and "frame_level" to just "strata" and "level"
 - Renamed "blink_period" to "blink_time"
 - Renamed "clear_history" to "clear_history_lines"
 - Improved consistency of enable/disable functions: for a boolean property X that can be enabled and disabled, there should be `enable_X()`, `disable_X()` and `set_X_enabled(bool)`.
 - Reduced code duplication with Lua region class names
 - Fixed edit_box "OnTextChanged" not always triggered when text is changed.
 - Fixed #88
 - Changed edit_box "OnCursorChanged" to trigger immediately, and not buffered until `update()`
 - Add `vertex_cache_strategy` to `font_string`
 - Add `update_rate` to `frame`