### PR TITLE
Bug fixes for `scroll_frame` and added `render_target::save_to_file()`

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -102,6 +102,8 @@ Other changes:
  - gui: added frame::enable_mouse_click and frame::enable_mouse_move
  - gui: added font_string::set_vertex_cache_strategy
  - gui: added frame::set_update_rate
+ - gui: added render_target::save_to_file
+ - gui: added region::is_valid
  - gui: renamed gui::uiobject into gui::region, and merged with previous gui::region
  - gui: renamed gui::manager_impl into gui::renderer
  - gui: renamed gui::gl::manager into gui::gl::renderer

--- a/impl/gui/gl/CMakeLists.txt
+++ b/impl/gui/gl/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(lxgui-gl
     ${SRCROOT}/gui_gl_renderer_png.cpp
     ${SRCROOT}/gui_gl_material.cpp
     ${SRCROOT}/gui_gl_render_target.cpp
+    ${SRCROOT}/gui_gl_render_target_png.cpp
     ${SRCROOT}/gui_gl_vertex_cache.cpp
 )
 

--- a/impl/gui/gl/src/gui_gl_render_target.cpp
+++ b/impl/gui/gl/src/gui_gl_render_target.cpp
@@ -91,6 +91,28 @@ bool render_target::set_dimensions(const vector2ui& dimensions) {
     return false;
 }
 
+void render_target::save_to_file(std::string filename) const {
+    const auto width  = texture_->get_rect().width();
+    const auto height = texture_->get_rect().height();
+
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo_handle_);
+    std::vector<color32> data(width * height);
+    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, data.data());
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+    for (auto& c : data) {
+        float a = c.a / 255.0f;
+        // De-multiply alpha
+        if (a > 0) {
+            c.r /= a;
+            c.g /= a;
+            c.b /= a;
+        }
+    }
+
+    save_rgba_to_png_(filename, data.data(), width, height);
+}
+
 std::weak_ptr<gl::material> render_target::get_material() {
     return texture_;
 }

--- a/impl/gui/gl/src/gui_gl_render_target.cpp
+++ b/impl/gui/gl/src/gui_gl_render_target.cpp
@@ -100,9 +100,9 @@ void render_target::save_to_file(std::string filename) const {
     glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, data.data());
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
+    // De-multiply alpha
     for (auto& c : data) {
         float a = c.a / 255.0f;
-        // De-multiply alpha
         if (a > 0) {
             c.r /= a;
             c.g /= a;

--- a/impl/gui/gl/src/gui_gl_render_target_png.cpp
+++ b/impl/gui/gl/src/gui_gl_render_target_png.cpp
@@ -1,6 +1,7 @@
 #include "lxgui/gui_exception.hpp"
 #include "lxgui/gui_out.hpp"
 #include "lxgui/impl/gui_gl_render_target.hpp"
+#include "lxgui/utils_string.hpp"
 
 #include <fstream>
 #include <png.h>
@@ -25,6 +26,11 @@ namespace lxgui::gui::gl {
 
 void render_target::save_rgba_to_png_(
     const std::string& file_name, const color32* data, std::size_t width, std::size_t height) {
+
+    if (!utils::ends_with(utils::to_lower(file_name), ".png")) {
+        throw gui::exception(
+            "gui::gl::manager", "Only PNG format is supported when saving images.");
+    }
 
     std::ofstream file(file_name, std::ios::binary);
     if (!file.is_open()) {

--- a/impl/gui/gl/src/gui_gl_render_target_png.cpp
+++ b/impl/gui/gl/src/gui_gl_render_target_png.cpp
@@ -52,7 +52,13 @@ void render_target::save_rgba_to_png_(
         png_write_info(write_struct, info_struct);
 
         for (std::size_t y = 0; y < height; ++y) {
+#if PNG_LIBPNG_VER_MAJOR == 1 && PNG_LIBPNG_VER_MINOR < 5
+            // Older versions of libpng were not const-correct
+            color32* non_const_data = const_cast<color32*>(data);
+            png_write_row(write_struct, reinterpret_cast<png_byte*>(non_const_data + y * width));
+#else
             png_write_row(write_struct, reinterpret_cast<const png_byte*>(data + y * width));
+#endif
         }
 
         png_write_end(write_struct, NULL);

--- a/impl/gui/gl/src/gui_gl_render_target_png.cpp
+++ b/impl/gui/gl/src/gui_gl_render_target_png.cpp
@@ -41,7 +41,7 @@ void render_target::save_rgba_to_png_(
     png_infop   info_struct  = nullptr;
 
     try {
-        write_struct = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+        write_struct = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, raise_error, NULL);
         if (!write_struct)
             throw gui::exception("gui::gl::manager", "'png_create_write_struct' failed.");
 

--- a/impl/gui/gl/src/gui_gl_render_target_png.cpp
+++ b/impl/gui/gl/src/gui_gl_render_target_png.cpp
@@ -1,0 +1,73 @@
+#include "lxgui/gui_exception.hpp"
+#include "lxgui/gui_out.hpp"
+#include "lxgui/impl/gui_gl_render_target.hpp"
+
+#include <fstream>
+#include <png.h>
+
+namespace {
+[[noreturn]] void raise_error(png_struct* /*png*/, char const* message) {
+    throw lxgui::gui::exception("gui::gl::manager", message);
+}
+
+void write_data(png_structp write_struct, png_bytep data, png_size_t length) {
+    png_voidp p = png_get_io_ptr(write_struct);
+    static_cast<std::ofstream*>(p)->write(reinterpret_cast<char*>(data), length);
+}
+
+void flush_data(png_structp write_struct) {
+    png_voidp p = png_get_io_ptr(write_struct);
+    static_cast<std::ofstream*>(p)->flush();
+}
+} // namespace
+
+namespace lxgui::gui::gl {
+
+void render_target::save_rgba_to_png_(
+    const std::string& file_name, const color32* data, std::size_t width, std::size_t height) {
+
+    std::ofstream file(file_name, std::ios::binary);
+    if (!file.is_open()) {
+        throw gui::exception("gui::gl::manager", "Cannot write file '" + file_name + "'.");
+    }
+
+    png_structp write_struct = nullptr;
+    png_infop   info_struct  = nullptr;
+
+    try {
+        write_struct = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+        if (!write_struct)
+            throw gui::exception("gui::gl::manager", "'png_create_write_struct' failed.");
+
+        info_struct = png_create_info_struct(write_struct);
+        if (!info_struct)
+            throw gui::exception("gui::gl::manager", "'png_create_info_struct' failed.");
+
+        png_set_write_fn(write_struct, static_cast<png_voidp>(&file), write_data, flush_data);
+
+        png_set_IHDR(
+            write_struct, info_struct, width, height, 8, PNG_COLOR_TYPE_RGB_ALPHA,
+            PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_BASE, PNG_FILTER_TYPE_BASE);
+
+        png_write_info(write_struct, info_struct);
+
+        for (std::size_t y = 0; y < height; ++y) {
+            png_write_row(write_struct, reinterpret_cast<const png_byte*>(data + y * width));
+        }
+
+        png_write_end(write_struct, NULL);
+    } catch (const gui::exception& e) {
+        gui::out << gui::error << "gui::gl::manager: Error writing " << file_name << "."
+                 << std::endl;
+        gui::out << gui::error << e.what() << "" << std::endl;
+
+        if (write_struct && info_struct)
+            png_destroy_write_struct(&write_struct, &info_struct);
+        else if (write_struct)
+            png_destroy_write_struct(&write_struct, nullptr);
+
+        throw;
+    }
+}
+
+} // namespace lxgui::gui::gl

--- a/impl/gui/gl/src/gui_gl_renderer_png.cpp
+++ b/impl/gui/gl/src/gui_gl_renderer_png.cpp
@@ -8,16 +8,18 @@
 #include <memory>
 #include <png.h>
 
-namespace lxgui::gui::gl {
-
+namespace {
 [[noreturn]] void raise_error(png_struct* /*png*/, char const* message) {
-    throw gui::exception("gui::gl::manager", message);
+    throw lxgui::gui::exception("gui::gl::manager", message);
 }
 
 void read_data(png_structp read_struct, png_bytep data, png_size_t length) {
     png_voidp p = png_get_io_ptr(read_struct);
     static_cast<std::ifstream*>(p)->read(reinterpret_cast<char*>(data), length);
 }
+} // namespace
+
+namespace lxgui::gui::gl {
 
 std::shared_ptr<gui::material>
 renderer::create_material_png_(const std::string& file_name, material::filter filt) const {

--- a/impl/gui/sdl/src/gui_sdl_render_target.cpp
+++ b/impl/gui/sdl/src/gui_sdl_render_target.cpp
@@ -52,6 +52,20 @@ void render_target::save_to_file(std::string filename) const {
     SDL_Surface* surface = SDL_CreateRGBSurface(
         0, texture_->get_rect().width(), texture_->get_rect().height(), 32, 0, 0, 0, 0);
     SDL_RenderReadPixels(renderer, NULL, surface->format->format, surface->pixels, surface->pitch);
+
+    // De-multiply alpha
+    color32* pixel_data = reinterpret_cast<color32*>(surface->pixels);
+
+    const std::size_t area = surface->w * surface->h;
+    for (std::size_t i = 0; i < area; ++i) {
+        float a = pixel_data[i].a / 255.0f;
+        if (a > 0.0f) {
+            pixel_data[i].r /= a;
+            pixel_data[i].g /= a;
+            pixel_data[i].b /= a;
+        }
+    }
+
     IMG_SavePNG(surface, filename.c_str());
     SDL_FreeSurface(surface);
 

--- a/impl/gui/sdl/src/gui_sdl_render_target.cpp
+++ b/impl/gui/sdl/src/gui_sdl_render_target.cpp
@@ -4,6 +4,7 @@
 #include "lxgui/impl/gui_sdl_renderer.hpp"
 
 #include <SDL.h>
+#include <SDL_image.h>
 #include <iostream>
 
 namespace lxgui::gui::sdl {
@@ -41,6 +42,20 @@ vector2ui render_target::get_canvas_dimensions() const {
 
 bool render_target::set_dimensions(const vector2ui& dimensions) {
     return texture_->set_dimensions(dimensions);
+}
+
+void render_target::save_to_file(std::string filename) const {
+    SDL_Renderer* renderer = texture_->get_renderer();
+    SDL_Texture*  target   = SDL_GetRenderTarget(renderer);
+    SDL_SetRenderTarget(renderer, texture_->get_render_texture());
+
+    SDL_Surface* surface = SDL_CreateRGBSurface(
+        0, texture_->get_rect().width(), texture_->get_rect().height(), 32, 0, 0, 0, 0);
+    SDL_RenderReadPixels(renderer, NULL, surface->format->format, surface->pixels, surface->pitch);
+    IMG_SavePNG(surface, filename.c_str());
+    SDL_FreeSurface(surface);
+
+    SDL_SetRenderTarget(renderer, target);
 }
 
 std::weak_ptr<sdl::material> render_target::get_material() {

--- a/impl/gui/sfml/src/gui_sfml_material.cpp
+++ b/impl/gui/sfml/src/gui_sfml_material.cpp
@@ -133,7 +133,7 @@ void material::update_texture(const color32* data) {
 void material::premultiply_alpha(sf::Image& data) {
     const std::size_t width  = data.getSize().x;
     const std::size_t height = data.getSize().y;
-    for (std::size_t x = 0; x < width; ++x)
+    for (std::size_t x = 0; x < width; ++x) {
         for (std::size_t y = 0; y < height; ++y) {
             sf::Color c = data.getPixel(x, y);
             float     a = c.a / 255.0f;
@@ -142,6 +142,7 @@ void material::premultiply_alpha(sf::Image& data) {
             c.b *= a;
             data.setPixel(x, y, c);
         }
+    }
 }
 
 bounds2f material::get_rect() const {

--- a/impl/gui/sfml/src/gui_sfml_render_target.cpp
+++ b/impl/gui/sfml/src/gui_sfml_render_target.cpp
@@ -34,6 +34,10 @@ bool render_target::set_dimensions(const vector2ui& dimensions) {
     return texture_->set_dimensions(dimensions);
 }
 
+void render_target::save_to_file(std::string filename) const {
+    render_texture_->getTexture().copyToImage().saveToFile(filename);
+}
+
 std::weak_ptr<sfml::material> render_target::get_material() {
     return texture_;
 }

--- a/impl/gui/sfml/src/gui_sfml_render_target.cpp
+++ b/impl/gui/sfml/src/gui_sfml_render_target.cpp
@@ -35,7 +35,25 @@ bool render_target::set_dimensions(const vector2ui& dimensions) {
 }
 
 void render_target::save_to_file(std::string filename) const {
-    render_texture_->getTexture().copyToImage().saveToFile(filename);
+    auto image = render_texture_->getTexture().copyToImage();
+
+    // De-multiply alpha
+    const std::size_t width  = image.getSize().x;
+    const std::size_t height = image.getSize().y;
+    for (std::size_t x = 0; x < width; ++x) {
+        for (std::size_t y = 0; y < height; ++y) {
+            sf::Color c = image.getPixel(x, y);
+            float     a = c.a / 255.0f;
+            if (a > 0.0f) {
+                c.r /= a;
+                c.g /= a;
+                c.b /= a;
+            }
+            image.setPixel(x, y, c);
+        }
+    }
+
+    image.saveToFile(filename);
 }
 
 std::weak_ptr<sfml::material> render_target::get_material() {

--- a/include/lxgui/gui_frame.hpp
+++ b/include/lxgui/gui_frame.hpp
@@ -1822,8 +1822,6 @@ protected:
     bool is_resizable_           = false;
     bool is_user_placed_         = false;
 
-    bool build_layer_list_flag_ = false;
-
     bounds2f abs_hit_rect_inset_list_ = bounds2f::zero;
     bounds2f rel_hit_rect_inset_list_ = bounds2f::zero;
 

--- a/include/lxgui/gui_frame_renderer.hpp
+++ b/include/lxgui/gui_frame_renderer.hpp
@@ -95,7 +95,6 @@ protected:
     void clear_strata_list_();
     bool has_strata_list_changed_() const;
     void reset_strata_list_changed_flag_();
-    void notify_strata_needs_redraw_(strata_data& strata_obj);
 
     void render_strata_(const strata_data& strata_obj) const;
 

--- a/include/lxgui/gui_region.hpp
+++ b/include/lxgui/gui_region.hpp
@@ -306,6 +306,17 @@ public:
     bool is_visible() const;
 
     /**
+     * \brief Checks if this region has all its borders correctly defined.
+     * \return 'true' if this region has all its borders correctly defined
+     * \note To be valid, a region needs to have a defined position and size along
+     * both the X and Y dimensions. This means either one anchor and a set size,
+     * or two opposite anchors. For example, any anchor plus a call to set_dimensions().
+     * Or a top_left plus a bottom_right anchors. Or a left plus a right anchors plus a
+     * call to set_height().
+     */
+    bool is_valid() const;
+
+    /**
      * \brief Changes this region's absolute dimensions (in pixels).
      * \param dimensions The new dimensions
      */
@@ -794,7 +805,7 @@ protected:
     bool is_manually_inherited_ = false;
     bool is_virtual_            = false;
     bool is_loaded_             = false;
-    bool is_ready_              = true;
+    bool is_valid_              = true;
 
     std::array<std::optional<anchor>, 9> anchor_list_;
     bounds2<bool>                        defined_borders_;

--- a/include/lxgui/gui_render_target.hpp
+++ b/include/lxgui/gui_render_target.hpp
@@ -67,6 +67,14 @@ public:
      * for example.
      */
     virtual vector2ui get_canvas_dimensions() const = 0;
+
+    /**
+     * \brief Saves the content of this render target into a file.
+     * \param filename The path of the file to save to
+     * \note The file format will be detected based on the extension.
+     * Not all renderer backends support all extensions.
+     */
+    virtual void save_to_file(std::string filename) const = 0;
 };
 
 } // namespace lxgui::gui

--- a/include/lxgui/gui_scroll_frame.hpp
+++ b/include/lxgui/gui_scroll_frame.hpp
@@ -143,13 +143,6 @@ public:
     void notify_strata_needs_redraw(strata strata_id) override;
 
     /**
-     * \brief Tells this renderer that it should (or not) render another frame.
-     * \param obj The frame to render
-     * \param rendered 'true' if this renderer needs to render that new object
-     */
-    void notify_rendered_frame(const utils::observer_ptr<frame>& obj, bool rendered) override;
-
-    /**
      * \brief Returns the width and height of of this renderer's main render target (e.g., screen).
      * \return The render target dimensions
      */

--- a/include/lxgui/gui_scroll_frame.hpp
+++ b/include/lxgui/gui_scroll_frame.hpp
@@ -172,7 +172,7 @@ protected:
     vector2f scroll_range_;
 
     utils::observer_ptr<frame> scroll_child_ = nullptr;
-    utils::connection          scroll_child_on_resize_connection_;
+    utils::scoped_connection   scroll_child_on_resize_connection_;
 
     bool                           redraw_scroll_render_target_flag_ = false;
     std::shared_ptr<render_target> scroll_render_target_;

--- a/include/lxgui/gui_scroll_frame.hpp
+++ b/include/lxgui/gui_scroll_frame.hpp
@@ -179,9 +179,9 @@ protected:
     vector2f scroll_range_;
 
     utils::observer_ptr<frame> scroll_child_ = nullptr;
+    utils::connection          scroll_child_on_resize_connection_;
 
-    bool                           rebuild_scroll_render_target_flag_ = false;
-    bool                           redraw_scroll_render_target_flag_  = false;
+    bool                           redraw_scroll_render_target_flag_ = false;
     std::shared_ptr<render_target> scroll_render_target_;
 
     utils::observer_ptr<texture> scroll_texture_ = nullptr;

--- a/include/lxgui/gui_text.hpp
+++ b/include/lxgui/gui_text.hpp
@@ -437,7 +437,6 @@ private:
 
     renderer& renderer_;
 
-    bool        is_ready_               = false;
     float       scaling_factor_         = 1.0f;
     float       tracking_               = 0.0f;
     float       line_spacing_           = 1.0f;

--- a/include/lxgui/impl/gui_gl_render_target.hpp
+++ b/include/lxgui/impl/gui_gl_render_target.hpp
@@ -59,6 +59,14 @@ public:
     vector2ui get_canvas_dimensions() const override;
 
     /**
+     * \brief Saves the content of this render target into a file.
+     * \param filename The path of the file to save to
+     * \note The file format will be detected based on the extension.
+     * Not all renderer backends support all extensions.
+     */
+    void save_to_file(std::string filename) const override;
+
+    /**
      * \brief Returns the associated texture for rendering.
      * \return The underlying pixel buffer, that you can use to render its content
      */
@@ -77,6 +85,9 @@ public:
     static void check_availability();
 
 private:
+    static void save_rgba_to_png_(
+        const std::string& filename, const color32* data, std::size_t width, std::size_t height);
+
     std::uint32_t                 fbo_handle_ = 0;
     std::shared_ptr<gl::material> texture_;
 

--- a/include/lxgui/impl/gui_sdl_render_target.hpp
+++ b/include/lxgui/impl/gui_sdl_render_target.hpp
@@ -64,6 +64,14 @@ public:
     vector2ui get_canvas_dimensions() const override;
 
     /**
+     * \brief Saves the content of this render target into a file.
+     * \param filename The path of the file to save to
+     * \note The file format will be detected based on the extension.
+     * Not all renderer backends support all extensions.
+     */
+    void save_to_file(std::string filename) const override;
+
+    /**
      * \brief Returns the associated texture for rendering.
      * \return The underlying pixel buffer, that you can use to render its content
      */

--- a/include/lxgui/impl/gui_sfml_render_target.hpp
+++ b/include/lxgui/impl/gui_sfml_render_target.hpp
@@ -56,6 +56,14 @@ public:
     bool set_dimensions(const vector2ui& dimensions) override;
 
     /**
+     * \brief Saves the content of this render target into a file.
+     * \param filename The path of the file to save to
+     * \note The file format will be detected based on the extension.
+     * Not all renderer backends support all extensions.
+     */
+    void save_to_file(std::string filename) const override;
+
+    /**
      * \brief Returns this render target's canvas dimension.
      * \return This render target's canvas dimension
      * \note This is the physical size of the render target.

--- a/include/lxgui/utils_string.hpp
+++ b/include/lxgui/utils_string.hpp
@@ -265,6 +265,8 @@ template<typename... Args>
     return utils::utf8_to_unicode(to_string(std::forward<Args>(args)...));
 }
 
+[[nodiscard]] string to_lower(string str);
+
 } // namespace lxgui::utils
 
 /** \endcond

--- a/src/gui_font_string.cpp
+++ b/src/gui_font_string.cpp
@@ -21,7 +21,7 @@ font_string::font_string(
 void font_string::render() const {
     base::render();
 
-    if (!text_ || !is_ready_ || !is_visible())
+    if (!text_ || !is_valid_ || !is_visible())
         return;
 
     text_->set_use_vertex_cache(is_vertex_cache_used_());
@@ -466,9 +466,9 @@ void font_string::update_borders_() {
 //#define DEBUG_LOG(msg) gui::out << (msg) << std::endl
 #define DEBUG_LOG(msg)
 
-    const bool old_ready       = is_ready_;
+    const bool old_valid       = is_valid_;
     const auto old_border_list = borders_;
-    is_ready_                  = true;
+    is_valid_                  = true;
 
     if (!anchor_list_.empty()) {
         float left = 0.0f, right = 0.0f, top = 0.0f, bottom = 0.0f;
@@ -501,14 +501,14 @@ void font_string::update_borders_() {
             box_width = text_->get_width();
 
         if (!make_borders_(top, bottom, y_center, box_height)) {
-            is_ready_ = false;
+            is_valid_ = false;
         }
 
         if (!make_borders_(left, right, x_center, box_width)) {
-            is_ready_ = false;
+            is_valid_ = false;
         }
 
-        if (is_ready_) {
+        if (is_valid_) {
             if (right < left) {
                 right = left + 1.0f;
             }
@@ -535,7 +535,7 @@ void font_string::update_borders_() {
         }
 
         borders_  = bounds2f(0.0, 0.0, box_width, box_height);
-        is_ready_ = false;
+        is_valid_ = false;
     }
 
     borders_.left   = round_to_pixel(borders_.left);
@@ -543,7 +543,7 @@ void font_string::update_borders_() {
     borders_.top    = round_to_pixel(borders_.top);
     borders_.bottom = round_to_pixel(borders_.bottom);
 
-    if (borders_ != old_border_list || is_ready_ != old_ready) {
+    if (borders_ != old_border_list || is_valid_ != old_valid) {
         DEBUG_LOG("  Fire redraw");
         notify_renderer_need_redraw();
     }

--- a/src/gui_font_string.cpp
+++ b/src/gui_font_string.cpp
@@ -128,9 +128,11 @@ void font_string::set_outlined(bool is_outlined) {
 
     is_outlined_ = is_outlined;
 
-    create_text_object_();
+    if (!is_virtual_) {
+        create_text_object_();
 
-    notify_renderer_need_redraw();
+        notify_renderer_need_redraw();
+    }
 }
 
 bool font_string::is_outlined() const {
@@ -345,6 +347,7 @@ void font_string::set_non_space_wrap_enabled(bool is_non_space_wrap_enabled) {
         return;
 
     non_space_wrap_enabled_ = is_non_space_wrap_enabled;
+
     if (!is_virtual_)
         notify_renderer_need_redraw();
 }
@@ -358,14 +361,22 @@ void font_string::set_shadow_enabled(bool is_shadow_enabled) {
         return;
 
     is_shadow_enabled_ = is_shadow_enabled;
+
     if (!is_virtual_)
         notify_renderer_need_redraw();
 }
 
 void font_string::set_word_wrap_enabled(bool enabled) {
+    if (word_wrap_enabled_ == enabled)
+        return;
+
     word_wrap_enabled_ = enabled;
-    if (text_)
+
+    if (text_) {
         text_->set_word_wrap_enabled(word_wrap_enabled_);
+        if (!is_virtual_)
+            notify_renderer_need_redraw();
+    }
 }
 
 bool font_string::is_word_wrap_enabled() const {
@@ -373,9 +384,16 @@ bool font_string::is_word_wrap_enabled() const {
 }
 
 void font_string::set_word_ellipsis_enabled(bool enabled) {
+    if (ellipsis_enabled_ == enabled)
+        return;
+
     ellipsis_enabled_ = enabled;
-    if (text_)
+
+    if (text_) {
         text_->set_word_ellipsis_enabled(ellipsis_enabled_);
+        if (!is_virtual_)
+            notify_renderer_need_redraw();
+    }
 }
 
 bool font_string::is_word_ellipsis_enabled() const {
@@ -383,9 +401,16 @@ bool font_string::is_word_ellipsis_enabled() const {
 }
 
 void font_string::set_formatting_enabled(bool formatting) {
+    if (formatting_enabled_ == formatting)
+        return;
+
     formatting_enabled_ = formatting;
-    if (text_)
+
+    if (text_) {
         text_->set_formatting_enabled(formatting_enabled_);
+        if (!is_virtual_)
+            notify_renderer_need_redraw();
+    }
 }
 
 bool font_string::is_formatting_enabled() const {
@@ -400,8 +425,10 @@ void font_string::set_text(const utils::ustring& content) {
 
     if (text_) {
         text_->set_text(content_);
-        if (!is_virtual_)
+        if (!is_virtual_) {
             notify_borders_need_update();
+            notify_renderer_need_redraw();
+        }
     }
 }
 

--- a/src/gui_frame.cpp
+++ b/src/gui_frame.cpp
@@ -63,7 +63,7 @@ frame::~frame() {
 void frame::render() const {
     base::render();
 
-    if (!is_visible() || !is_ready_)
+    if (!is_visible() || !is_valid_)
         return;
 
     if (backdrop_) {
@@ -1500,14 +1500,14 @@ void frame::notify_mouse_in_frame(bool mouse_in_frame, const vector2f& /*positio
 }
 
 void frame::update_borders_() {
-    const bool old_ready       = is_ready_;
+    const bool old_valid       = is_valid_;
     const auto old_border_list = borders_;
 
     base::update_borders_();
 
     check_position_();
 
-    if (borders_ != old_border_list || is_ready_ != old_ready) {
+    if (borders_ != old_border_list || is_valid_ != old_valid) {
         if (borders_.width() != old_border_list.width() ||
             borders_.height() != old_border_list.height()) {
             alive_checker checker(*this);

--- a/src/gui_frame.cpp
+++ b/src/gui_frame.cpp
@@ -1550,7 +1550,7 @@ void frame::update_(float delta) {
             layer.region_list.clear();
 
         // Fill layers with regions (with font_string rendered last within the same layer)
-        // TODO: This is bad; the frame class should not know about font_string, see #.
+        // TODO: This is bad; the frame class should not know about font_string, see #112.
         for (const auto& reg : region_list_) {
             if (reg && !reg->is_region_type<font_string>()) {
                 layer_list_[static_cast<std::size_t>(reg->get_draw_layer())].region_list.push_back(

--- a/src/gui_frame_renderer.cpp
+++ b/src/gui_frame_renderer.cpp
@@ -75,12 +75,8 @@ frame_renderer::frame_renderer() {
     }
 }
 
-void frame_renderer::notify_strata_needs_redraw_(strata_data& strata_obj) {
-    strata_obj.redraw_flag = true;
-}
-
 void frame_renderer::notify_strata_needs_redraw(strata strata_id) {
-    notify_strata_needs_redraw_(strata_list_[static_cast<std::size_t>(strata_id)]);
+    strata_list_[static_cast<std::size_t>(strata_id)].redraw_flag = true;
 }
 
 void frame_renderer::notify_rendered_frame(const utils::observer_ptr<frame>& obj, bool rendered) {
@@ -109,7 +105,7 @@ void frame_renderer::notify_rendered_frame(const utils::observer_ptr<frame>& obj
     auto&      strata_obj = strata_list_[static_cast<std::size_t>(strata_id)];
 
     frame_list_updated_ = true;
-    notify_strata_needs_redraw_(strata_obj);
+    notify_strata_needs_redraw(strata_id);
 }
 
 void frame_renderer::notify_strata_changed(
@@ -122,12 +118,9 @@ void frame_renderer::notify_strata_changed(
         strata_list_[i].range = get_strata_range_(static_cast<strata>(i));
     }
 
-    auto& old_strata = strata_list_[static_cast<std::size_t>(old_strata_id)];
-    auto& new_strata = strata_list_[static_cast<std::size_t>(new_strata_id)];
-
     frame_list_updated_ = true;
-    notify_strata_needs_redraw_(old_strata);
-    notify_strata_needs_redraw_(new_strata);
+    notify_strata_needs_redraw(old_strata_id);
+    notify_strata_needs_redraw(new_strata_id);
 }
 
 std::pair<std::size_t, std::size_t> frame_renderer::get_strata_range_(strata strata_id) const {
@@ -150,7 +143,7 @@ void frame_renderer::notify_level_changed(
     std::stable_sort(begin, last, sorted_frame_list_.comparator());
 
     frame_list_updated_ = true;
-    notify_strata_needs_redraw_(strata_obj);
+    notify_strata_needs_redraw(strata_id);
 }
 
 utils::observer_ptr<const frame>

--- a/src/gui_frame_renderer.cpp
+++ b/src/gui_frame_renderer.cpp
@@ -101,8 +101,7 @@ void frame_renderer::notify_rendered_frame(const utils::observer_ptr<frame>& obj
         strata_list_[i].range = get_strata_range_(static_cast<strata>(i));
     }
 
-    const auto strata_id  = obj->get_effective_strata();
-    auto&      strata_obj = strata_list_[static_cast<std::size_t>(strata_id)];
+    const auto strata_id = obj->get_effective_strata();
 
     frame_list_updated_ = true;
     notify_strata_needs_redraw(strata_id);

--- a/src/gui_localizer.cpp
+++ b/src/gui_localizer.cpp
@@ -16,12 +16,6 @@
 namespace lxgui::gui {
 
 namespace {
-std::string to_lower(std::string str) {
-    for (char& c : str)
-        c = static_cast<char>(std::tolower(c));
-
-    return str;
-}
 
 std::string get_environment_variable(const std::string& name) {
 #if defined(LXGUI_PLATFORM_WINDOWS)
@@ -460,7 +454,7 @@ void localizer::add_allowed_code_points_for_group(const std::string& unicode_gro
         {"supplementary private use area-a", {0xf0000, 0xfffff}},
         {"supplementary private use area-b", {0x100000, 0x10ffff}}};
 
-    auto iter = unicode_groups.find(to_lower(unicode_group));
+    auto iter = unicode_groups.find(utils::to_lower(unicode_group));
     if (iter == unicode_groups.end())
         throw gui::exception("gui::localizer", "unknown Unicode group '" + unicode_group + "'");
 

--- a/src/gui_region.cpp
+++ b/src/gui_region.cpp
@@ -92,7 +92,7 @@ std::string region::serialize(const std::string& tab) const {
     std::ostringstream str;
 
     str << tab << "  # Name       : " << name_ << " ("
-        << std::string(is_ready_ ? "ready" : "not ready")
+        << std::string(is_valid_ ? "valid" : "not valid")
         << std::string(is_manually_inherited_ ? ", manually inherited" : "") << ")\n";
     str << tab << "  # Raw name   : " << raw_name_ << "\n";
     str << tab << "  # Type       : " << get_region_type() << "\n";
@@ -206,6 +206,10 @@ bool region::is_shown() const {
 
 bool region::is_visible() const {
     return is_visible_;
+}
+
+bool region::is_valid() const {
+    return is_valid_;
 }
 
 void region::set_dimensions(const vector2f& dimensions) {
@@ -668,10 +672,10 @@ void region::update_borders_() {
 
     DEBUG_LOG("  Update anchors for " + lua_name_);
 
-    const bool old_is_ready    = is_ready_;
+    const bool old_is_ready    = is_valid_;
     const auto old_border_list = borders_;
 
-    is_ready_ = true;
+    is_valid_ = true;
 
     if (!anchor_list_.empty()) {
         float left = 0.0f, right = 0.0f, top = 0.0f, bottom = 0.0f;
@@ -693,14 +697,14 @@ void region::update_borders_() {
 
         DEBUG_LOG("  Make borders");
         if (!make_borders_(top, bottom, y_center, rounded_height)) {
-            is_ready_ = false;
+            is_valid_ = false;
         }
 
         if (!make_borders_(left, right, x_center, rounded_width)) {
-            is_ready_ = false;
+            is_valid_ = false;
         }
 
-        if (is_ready_) {
+        if (is_valid_) {
             if (right < left) {
                 right = left + 1;
             }
@@ -714,7 +718,7 @@ void region::update_borders_() {
         }
     } else {
         borders_  = bounds2f(0.0, 0.0, dimensions_.x, dimensions_.y);
-        is_ready_ = false;
+        is_valid_ = false;
     }
 
     DEBUG_LOG("  Final borders");
@@ -728,7 +732,7 @@ void region::update_borders_() {
     DEBUG_LOG("    top=" + utils::to_string(borders_.top));
     DEBUG_LOG("    bottom=" + utils::to_string(borders_.bottom));
 
-    if (borders_ != old_border_list || is_ready_ != old_is_ready) {
+    if (borders_ != old_border_list || is_valid_ != old_is_ready) {
         DEBUG_LOG("  Fire redraw");
         notify_renderer_need_redraw();
     }
@@ -741,12 +745,12 @@ void region::notify_borders_need_update() {
     if (is_virtual())
         return;
 
-    const bool old_ready       = is_ready_;
+    const bool old_valid       = is_valid_;
     const auto old_border_list = borders_;
 
     update_borders_();
 
-    if (borders_ != old_border_list || is_ready_ != old_ready) {
+    if (borders_ != old_border_list || is_valid_ != old_valid) {
         for (const auto& object : anchored_object_list_)
             object->notify_borders_need_update();
     }

--- a/src/gui_region_glues.cpp
+++ b/src/gui_region_glues.cpp
@@ -261,6 +261,10 @@ void region::register_on_lua(sol::state& lua) {
      */
     type.set_function("is_visible", member_function<&region::is_visible>());
 
+    /** @function is_valid
+     */
+    type.set_function("is_valid", member_function<&region::is_valid>());
+
     /** @function set_all_anchors
      */
     type.set_function(

--- a/src/gui_scroll_frame.cpp
+++ b/src/gui_scroll_frame.cpp
@@ -178,7 +178,7 @@ void scroll_frame::update_(float delta) {
         return;
 
     if (is_visible()) {
-        if (scroll_child_ && scroll_render_target_ && redraw_scroll_render_target_flag_) {
+        if (scroll_render_target_ && redraw_scroll_render_target_flag_) {
             render_scroll_strata_list_();
             redraw_scroll_render_target_flag_ = false;
         }
@@ -186,6 +186,9 @@ void scroll_frame::update_(float delta) {
 }
 
 void scroll_frame::update_scroll_range_() {
+    if (!scroll_child_)
+        return;
+
     const vector2f apparent_size       = get_apparent_dimensions();
     const vector2f child_apparent_size = scroll_child_->get_apparent_dimensions();
     const auto     old_scroll_range    = scroll_range_;

--- a/src/gui_scroll_frame.cpp
+++ b/src/gui_scroll_frame.cpp
@@ -272,17 +272,6 @@ scroll_frame::find_topmost_frame(const std::function<bool(const frame&)>& predic
 
 void scroll_frame::notify_strata_needs_redraw(strata strata_id) {
     frame_renderer::notify_strata_needs_redraw(strata_id);
-
-    redraw_scroll_render_target_flag_ = true;
-    notify_renderer_need_redraw();
-}
-
-void scroll_frame::notify_rendered_frame(const utils::observer_ptr<frame>& obj, bool rendered) {
-    if (!obj)
-        return;
-
-    frame_renderer::notify_rendered_frame(obj, rendered);
-
     redraw_scroll_render_target_flag_ = true;
 }
 

--- a/src/gui_scroll_frame.cpp
+++ b/src/gui_scroll_frame.cpp
@@ -256,6 +256,8 @@ void scroll_frame::render_scroll_strata_list_() {
     }
 
     renderer.end();
+
+    notify_renderer_need_redraw();
 }
 
 utils::observer_ptr<const frame>

--- a/src/gui_scroll_frame.cpp
+++ b/src/gui_scroll_frame.cpp
@@ -235,8 +235,12 @@ void scroll_frame::rebuild_scroll_render_target_() {
             scroll_texture_->set_texture(scroll_render_target_);
     }
 
-    render_scroll_strata_list_();
-    redraw_scroll_render_target_flag_ = false;
+    if (scroll_render_target_) {
+        render_scroll_strata_list_();
+        redraw_scroll_render_target_flag_ = false;
+    } else {
+        notify_renderer_need_redraw();
+    }
 }
 
 void scroll_frame::render_scroll_strata_list_() {

--- a/src/gui_text.cpp
+++ b/src/gui_text.cpp
@@ -282,13 +282,7 @@ float get_string_width(const text& txt, const std::vector<item>& content) {
 
 text::text(
     renderer& rdr, std::shared_ptr<const font> fnt, std::shared_ptr<const font> outline_font) :
-    renderer_(rdr), font_(std::move(fnt)), outline_font_(std::move(outline_font)) {
-
-    if (!font_)
-        return;
-
-    is_ready_ = true;
-}
+    renderer_(rdr), font_(std::move(fnt)), outline_font_(std::move(outline_font)) {}
 
 float text::get_line_height() const {
     if (font_)
@@ -400,7 +394,7 @@ float text::get_text_width() const {
 }
 
 float text::get_text_height() const {
-    if (!is_ready_)
+    if (!font_)
         return 0.0f;
 
     std::size_t count  = std::count(unicode_text_.begin(), unicode_text_.end(), U'\n');
@@ -419,7 +413,7 @@ float text::get_string_width(const std::string& content) const {
 }
 
 float text::get_string_width(const utils::ustring& content) const {
-    if (!is_ready_)
+    if (!font_)
         return 0.0f;
 
     return parser::get_string_width(
@@ -427,7 +421,7 @@ float text::get_string_width(const utils::ustring& content) const {
 }
 
 float text::get_character_width(char32_t c) const {
-    if (!is_ready_)
+    if (!font_)
         return 0.0f;
     else if (c == U'\t')
         return 4.0f * font_->get_character_width(U' ') * scaling_factor_;
@@ -552,7 +546,7 @@ bool text::use_vertex_cache_() const {
 }
 
 void text::render(const matrix4f& transform) const {
-    if (!is_ready_ || unicode_text_.empty())
+    if (!font_ || unicode_text_.empty())
         return;
 
     update_();
@@ -624,7 +618,7 @@ float text::round_to_pixel_(float value, utils::rounding_method method) const {
 }
 
 void text::update_() const {
-    if (!is_ready_ || !update_cache_flag_)
+    if (!font_ || !update_cache_flag_)
         return;
 
     // Update the line list, read format tags, do word wrapping, ...

--- a/src/gui_texture.cpp
+++ b/src/gui_texture.cpp
@@ -288,9 +288,6 @@ void texture::set_texture(const std::string& file_name) {
     std::string parsed_file = parse_file_name(file_name);
     content_                = parsed_file;
 
-    if (parsed_file.empty())
-        return;
-
     auto& renderer = get_manager().get_renderer();
 
     std::shared_ptr<gui::material> mat;
@@ -310,7 +307,7 @@ void texture::set_texture(const std::string& file_name) {
 
         if (!is_apparent_height_defined())
             set_height(quad_.mat->get_rect().height());
-    } else {
+    } else if (!parsed_file.empty()) {
         gui::out << gui::error << "gui::" << get_region_type() << ": "
                  << "Cannot load file \"" << parsed_file << "\" for \"" << name_
                  << "\". Using white texture instead." << std::endl;

--- a/src/utils_string.cpp
+++ b/src/utils_string.cpp
@@ -525,7 +525,7 @@ string to_string(const void* p) {
     return stream.str();
 }
 
-std::string to_string(const utils::variant& value) {
+string to_string(const utils::variant& value) {
     return std::visit(
         [&](const auto& inner_value) -> std::string {
             using inner_type = std::decay_t<decltype(inner_value)>;
@@ -535,6 +535,13 @@ std::string to_string(const utils::variant& value) {
                 return to_string(inner_value);
         },
         value);
+}
+
+string to_lower(string str) {
+    for (char& c : str)
+        c = static_cast<char>(std::tolower(c));
+
+    return str;
 }
 
 } // namespace lxgui::utils


### PR DESCRIPTION
Fixes #117. Changes:
 - Some logic in `scroll_frame` and `frame` have been moved from deferred (queued for execution in next call to `update()`) to immediate. This includes re-building the layer list for `frame`, and re-build the render target and update the scroll range for `scroll_frame`.
 - A bug was fixed in `frame_renderer` where internal calls to `notify_strata_needs_redraw_()` would not go through virtual dispatch, contrary to `notify_strata_needs_redraw()`, thereby preventing derived classes from listening to all strata changes.
 - A number of missing calls to `notify_renderer_need_redraw()` were added to the `font_string` class, in particular to `set_text()`, and a missing call to `scroll_frame` when the render target is refreshed.
 - The internal `is_ready_` flag has been renamed to `is_valid_` and is now exposed publicly for query.
 - `render_target` gained a new `save_to_file()` function, which is implemented in all back-ends (the OpenGL backend only supports PNG output).
 - Update oup to 0.7.0
 - Update pugixml to 1.12.1