### PR TITLE
Improve error handling and error messages with `layout_node`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build
 build_wasm
 build_clang
+build_examples
 bin/lxgui-test*
 bin/cout.txt
 bin/gui.txt

--- a/include/lxgui/gui_region.hpp
+++ b/include/lxgui/gui_region.hpp
@@ -736,11 +736,15 @@ public:
 
 protected:
     // Layout parsing
-    virtual void parse_attributes_(const layout_node& node);
-    virtual void parse_size_node_(const layout_node& node);
-    virtual void parse_anchor_node_(const layout_node& node);
-    color        parse_color_node_(const layout_node& node);
-    std::pair<anchor_type, vector2<std::optional<float>>> parse_dimension_(const layout_node& node);
+    virtual void                  parse_attributes_(const layout_node& node);
+    virtual void                  parse_size_node_(const layout_node& node);
+    virtual void                  parse_anchor_node_(const layout_node& node);
+    color                         parse_color_node_(const layout_node& node);
+    vector2<std::optional<float>> parse_offset_node_(const layout_node& node);
+    vector2<float>                parse_offset_node_or_(const layout_node& node, float fallback);
+
+    std::pair<anchor_type, vector2<std::optional<float>>>
+    parse_dimension_node_(const layout_node& node);
 
     void read_anchors_(
         float& left, float& right, float& top, float& bottom, float& x_center, float& y_center)

--- a/src/gui_animated_texture_parser.cpp
+++ b/src/gui_animated_texture_parser.cpp
@@ -12,17 +12,17 @@ void animated_texture::parse_layout(const layout_node& node) {
 void animated_texture::parse_attributes_(const layout_node& node) {
     layered_region::parse_attributes_(node);
 
-    if (const layout_attribute* attr = node.try_get_attribute("file"))
-        set_texture(attr->get_value<std::string>());
+    if (const auto attr = node.try_get_attribute_value<std::string>("file"))
+        set_texture(attr.value());
 
-    if (const layout_attribute* attr = node.try_get_attribute("speed"))
-        set_speed(attr->get_value<float>());
+    if (const auto attr = node.try_get_attribute_value<float>("speed"))
+        set_speed(attr.value());
 
-    if (const layout_attribute* attr = node.try_get_attribute("state"))
-        set_state(attr->get_value<float>());
+    if (const auto attr = node.try_get_attribute_value<float>("state"))
+        set_state(attr.value());
 
-    if (const layout_attribute* attr = node.try_get_attribute("paused"))
-        set_paused(attr->get_value<bool>());
+    if (const auto attr = node.try_get_attribute_value<bool>("paused"))
+        set_paused(attr.value());
 }
 
 } // namespace lxgui::gui

--- a/src/gui_button_parser.cpp
+++ b/src/gui_button_parser.cpp
@@ -11,10 +11,8 @@ namespace lxgui::gui {
 void button::parse_attributes_(const layout_node& node) {
     frame::parse_attributes_(node);
 
-    if (const layout_attribute* attr = node.try_get_attribute("text")) {
-        set_text(utils::utf8_to_unicode(
-            get_manager().get_localizer().localize(attr->get_value<std::string>())));
-    }
+    if (const auto attr = node.try_get_attribute_value<std::string>("text"))
+        set_text(utils::utf8_to_unicode(get_manager().get_localizer().localize(attr.value())));
 }
 
 void button::parse_all_nodes_before_children_(const layout_node& node) {
@@ -140,7 +138,7 @@ void button::parse_all_nodes_before_children_(const layout_node& node) {
     }
 
     if (const layout_node* offset_block = node.try_get_child("PushedTextOffset")) {
-        auto dimensions = parse_dimension_(*offset_block);
+        auto dimensions = parse_dimension_node_(*offset_block);
         if (dimensions.first == anchor_type::abs) {
             set_pushed_text_offset(
                 vector2f(dimensions.second.x.value_or(0.0f), dimensions.second.y.value_or(0.0f)));

--- a/src/gui_edit_box_parser.cpp
+++ b/src/gui_edit_box_parser.cpp
@@ -8,32 +8,32 @@ namespace lxgui::gui {
 void edit_box::parse_attributes_(const layout_node& node) {
     base::parse_attributes_(node);
 
-    if (const layout_attribute* attr = node.try_get_attribute("letters"))
-        set_max_letters(attr->get_value<std::size_t>());
+    if (const auto attr = node.try_get_attribute_value<std::size_t>("letters"))
+        set_max_letters(attr.value());
 
-    if (const layout_attribute* attr = node.try_get_attribute("blinkTime"))
-        set_blink_time(attr->get_value<float>());
+    if (const auto attr = node.try_get_attribute_value<float>("blinkTime"))
+        set_blink_time(attr.value());
 
-    if (const layout_attribute* attr = node.try_get_attribute("numeric"))
-        set_numeric_only(attr->get_value<bool>());
+    if (const auto attr = node.try_get_attribute_value<bool>("numeric"))
+        set_numeric_only(attr.value());
 
-    if (const layout_attribute* attr = node.try_get_attribute("positive"))
-        set_positive_only(attr->get_value<bool>());
+    if (const auto attr = node.try_get_attribute_value<bool>("positive"))
+        set_positive_only(attr.value());
 
-    if (const layout_attribute* attr = node.try_get_attribute("integer"))
-        set_integer_only(attr->get_value<bool>());
+    if (const auto attr = node.try_get_attribute_value<bool>("integer"))
+        set_integer_only(attr.value());
 
-    if (const layout_attribute* attr = node.try_get_attribute("password"))
-        set_password_mode_enabled(attr->get_value<bool>());
+    if (const auto attr = node.try_get_attribute_value<bool>("password"))
+        set_password_mode_enabled(attr.value());
 
-    if (const layout_attribute* attr = node.try_get_attribute("multiLine"))
-        set_multi_line(attr->get_value<bool>());
+    if (const auto attr = node.try_get_attribute_value<bool>("multiLine"))
+        set_multi_line(attr.value());
 
-    if (const layout_attribute* attr = node.try_get_attribute("historyLines"))
-        set_max_history_lines(attr->get_value<std::size_t>());
+    if (const auto attr = node.try_get_attribute_value<std::size_t>("historyLines"))
+        set_max_history_lines(attr.value());
 
-    if (const layout_attribute* attr = node.try_get_attribute("ignoreArrows"))
-        set_arrows_ignored(attr->get_value<bool>());
+    if (const auto attr = node.try_get_attribute_value<bool>("ignoreArrows"))
+        set_arrows_ignored(attr.value());
 }
 
 void edit_box::parse_all_nodes_before_children_(const layout_node& node) {

--- a/src/gui_font_string_parser.cpp
+++ b/src/gui_font_string_parser.cpp
@@ -22,23 +22,21 @@ void font_string::parse_attributes_(const layout_node& node) {
         node.get_attribute_value_or<std::string>("font", ""),
         node.get_attribute_value_or<float>("fontHeight", 0.0f));
 
-    if (const layout_attribute* attr = node.try_get_attribute("text")) {
-        set_text(utils::utf8_to_unicode(
-            get_manager().get_localizer().localize(attr->get_value<std::string>())));
-    }
+    if (const auto attr = node.try_get_attribute_value<std::string>("text"))
+        set_text(utils::utf8_to_unicode(get_manager().get_localizer().localize(attr.value())));
+    if (const auto attr = node.try_get_attribute_value<bool>("nonSpaceWrap"))
+        set_non_space_wrap_enabled(attr.value());
+    if (const auto attr = node.try_get_attribute_value<float>("spacing"))
+        set_spacing(attr.value());
+    if (const auto attr = node.try_get_attribute_value<float>("lineSpacing"))
+        set_line_spacing(attr.value());
 
-    if (const layout_attribute* attr = node.try_get_attribute("nonSpaceWrap"))
-        set_non_space_wrap_enabled(attr->get_value<bool>());
-    if (const layout_attribute* attr = node.try_get_attribute("spacing"))
-        set_spacing(attr->get_value<float>());
-    if (const layout_attribute* attr = node.try_get_attribute("lineSpacing"))
-        set_line_spacing(attr->get_value<float>());
-
-    if (const layout_attribute* attr = node.try_get_attribute("outline")) {
-        const std::string& outline = attr->get_value<std::string>();
-        if (outline == "NORMAL" || outline == "THICK")
+    if (const auto attr = node.try_get_attribute_value<std::string>("outline")) {
+        std::string outline = utils::to_lower(attr.value());
+        if (outline == "normal" || outline == "thick") {
+            // TODO: fix this in https://github.com/cschreib/lxgui/issues/121
             set_outlined(true);
-        else if (outline == "NONE")
+        } else if (outline == "none")
             set_outlined(false);
         else {
             gui::out << gui::warning << node.get_location() << ": "
@@ -47,12 +45,13 @@ void font_string::parse_attributes_(const layout_node& node) {
         }
     }
 
-    if (const layout_attribute* attr = node.try_get_attribute("alignX"))
-        set_alignment_x(attr->get_value<alignment_x>());
-    if (const layout_attribute* attr = node.try_get_attribute("alignY"))
-        set_alignment_y(attr->get_value<alignment_y>());
-    if (const layout_attribute* attr = node.try_get_attribute("vertexCacheStrategy"))
-        set_vertex_cache_strategy(attr->get_value<vertex_cache_strategy>());
+    if (const auto attr = node.try_get_attribute_value<alignment_x>("alignX"))
+        set_alignment_x(attr.value());
+    if (const auto attr = node.try_get_attribute_value<alignment_y>("alignY"))
+        set_alignment_y(attr.value());
+    if (const auto attr =
+            node.try_get_attribute_value<vertex_cache_strategy>("vertexCacheStrategy"))
+        set_vertex_cache_strategy(attr.value());
 }
 
 void font_string::parse_shadow_node_(const layout_node& node) {
@@ -63,9 +62,7 @@ void font_string::parse_shadow_node_(const layout_node& node) {
             set_shadow_color(parse_color_node_(*color_node));
 
         if (const layout_node* offset_node = shadow_node->try_get_child("Offset")) {
-            set_shadow_offset(vector2f(
-                offset_node->get_attribute_value_or<float>("x", 0.0),
-                offset_node->get_attribute_value_or<float>("y", 0.0)));
+            set_shadow_offset(parse_offset_node_or_(*offset_node, 0.0f));
         }
     }
 }

--- a/src/gui_layered_region_parser.cpp
+++ b/src/gui_layered_region_parser.cpp
@@ -14,8 +14,8 @@ void layered_region::parse_layout(const layout_node& node) {
 }
 
 void layered_region::parse_attributes_(const layout_node& node) {
-    if (const layout_attribute* attr = node.try_get_attribute("hidden"))
-        set_shown(attr->get_value<bool>());
+    if (const auto attr = node.try_get_attribute_value<bool>("hidden"))
+        set_shown(!attr.value());
 
     if (node.get_attribute_value_or<bool>("setAllAnchors", false))
         set_all_anchors("$parent");

--- a/src/gui_parser_common.cpp
+++ b/src/gui_parser_common.cpp
@@ -35,8 +35,8 @@ region_core_attributes parse_core_attributes(
     } else {
         attr.is_virtual = node.get_attribute_value_or<bool>("virtual", false);
 
-        if (const layout_attribute* parent_attr = node.try_get_attribute("parent")) {
-            std::string parent_name = parent_attr->get_value<std::string>();
+        if (const auto parent_attr = node.try_get_attribute_value<std::string>("parent")) {
+            std::string parent_name = parent_attr.value();
             auto        parent_obj  = reg.get_region_by_name(parent_name);
             if (!parent_name.empty() && !parent_obj) {
                 gui::out << gui::warning << node.get_location() << ": "
@@ -53,8 +53,8 @@ region_core_attributes parse_core_attributes(
         }
     }
 
-    if (const layout_attribute* inh_attr = node.try_get_attribute("inherits")) {
-        attr.inheritance = vreg.get_virtual_region_list(inh_attr->get_value<std::string>());
+    if (const auto inh_attr = node.try_get_attribute_value<std::string>("inherits")) {
+        attr.inheritance = vreg.get_virtual_region_list(inh_attr.value());
     }
 
     return attr;

--- a/src/gui_region_parser.cpp
+++ b/src/gui_region_parser.cpp
@@ -8,8 +8,8 @@
 namespace lxgui::gui {
 
 color region::parse_color_node_(const layout_node& node) {
-    if (const layout_attribute* attr = node.try_get_attribute("c")) {
-        std::string s = attr->get_value<std::string>();
+    if (const auto attr = node.try_get_attribute_value<std::string>("c")) {
+        const std::string& s = attr.value();
         if (!s.empty() && s[0] == '#')
             return color(s);
     }
@@ -21,8 +21,18 @@ color region::parse_color_node_(const layout_node& node) {
         node.get_attribute_value_or<float>("a", 1.0f));
 }
 
+vector2<std::optional<float>> region::parse_offset_node_(const layout_node& node) {
+    return {node.try_get_attribute_value<float>("x"), node.try_get_attribute_value<float>("y")};
+}
+
+vector2<float> region::parse_offset_node_or_(const layout_node& node, float fallback) {
+    return {
+        node.get_attribute_value_or<float>("x", fallback),
+        node.get_attribute_value_or<float>("y", fallback)};
+}
+
 std::pair<anchor_type, vector2<std::optional<float>>>
-region::parse_dimension_(const layout_node& node) {
+region::parse_dimension_node_(const layout_node& node) {
     const layout_node* abs_dim_node = node.try_get_child("AbsDimension");
     const layout_node* rel_dim_node = node.try_get_child("RelDimension");
 
@@ -49,15 +59,12 @@ region::parse_dimension_(const layout_node& node) {
         chosen_node = rel_dim_node;
     }
 
-    return std::make_pair(
-        type, vector2<std::optional<float>>(
-                  chosen_node->try_get_attribute_value<float>("x"),
-                  chosen_node->try_get_attribute_value<float>("y")));
+    return std::make_pair(type, parse_offset_node_(*chosen_node));
 }
 
 void region::parse_size_node_(const layout_node& node) {
     if (const layout_node* size_block = node.try_get_child("Size")) {
-        auto dimensions = parse_dimension_(*size_block);
+        auto dimensions = parse_dimension_node_(*size_block);
         bool has_x      = dimensions.second.x.has_value();
         bool has_y      = dimensions.second.y.has_value();
         if (dimensions.first == anchor_type::abs) {
@@ -106,7 +113,7 @@ void region::parse_anchor_node_(const layout_node& node) {
             anchor_data a(pt, parent, relative_point);
 
             if (const layout_node* offset_node = anchor_node.try_get_child("Offset")) {
-                auto dimensions = parse_dimension_(*offset_node);
+                auto dimensions = parse_dimension_node_(*offset_node);
                 a.type          = dimensions.first;
                 a.offset        = vector2f(
                     dimensions.second.x.value_or(0.0f), dimensions.second.y.value_or(0.0f));

--- a/src/gui_region_parser.cpp
+++ b/src/gui_region_parser.cpp
@@ -49,18 +49,10 @@ region::parse_dimension_(const layout_node& node) {
         chosen_node = rel_dim_node;
     }
 
-    vector2<std::optional<float>> vec;
-    if (const layout_attribute* attr = chosen_node->try_get_attribute("x"))
-        vec.x = attr->get_value<float>();
-    else
-        vec.x = std::nullopt;
-
-    if (const layout_attribute* attr = chosen_node->try_get_attribute("y"))
-        vec.y = attr->get_value<float>();
-    else
-        vec.y = std::nullopt;
-
-    return std::make_pair(type, vec);
+    return std::make_pair(
+        type, vector2<std::optional<float>>(
+                  chosen_node->try_get_attribute_value<float>("x"),
+                  chosen_node->try_get_attribute_value<float>("y")));
 }
 
 void region::parse_size_node_(const layout_node& node) {

--- a/src/gui_slider_parser.cpp
+++ b/src/gui_slider_parser.cpp
@@ -9,35 +9,18 @@ namespace lxgui::gui {
 void slider::parse_attributes_(const layout_node& node) {
     frame::parse_attributes_(node);
 
-    if (const layout_attribute* attr = node.try_get_attribute("valueStep"))
-        set_value_step(attr->get_value<float>());
-    if (const layout_attribute* attr = node.try_get_attribute("minValue"))
-        set_min_value(attr->get_value<float>());
-    if (const layout_attribute* attr = node.try_get_attribute("maxValue"))
-        set_max_value(attr->get_value<float>());
-    if (const layout_attribute* attr = node.try_get_attribute("defaultValue"))
-        set_value(attr->get_value<float>());
-    if (const layout_attribute* attr = node.try_get_attribute("drawLayer")) {
-        std::string layer_name = attr->get_value<std::string>();
-        if (auto converted = utils::from_string<layer>(layer_name); converted.has_value()) {
-            set_thumb_draw_layer(converted.value());
-        } else {
-            gui::out << gui::warning << node.get_location() << ": Unknown Slider draw layer: \""
-                     << layer_name << "\". Attribute ignored." << std::endl;
-        }
-    }
-
-    if (const layout_attribute* attr = node.try_get_attribute("orientation")) {
-        std::string orient = attr->get_value<std::string>();
-        if (auto converted = utils::from_string<orientation>(orient); converted.has_value()) {
-            set_orientation(converted.value());
-        } else {
-            gui::out << gui::warning << node.get_location() << ": Unknown Slider orientation: \""
-                     << orient
-                     << "\". Expecting either \"HORIZONTAL\" or \"VERTICAL\". Attribute ignored."
-                     << std::endl;
-        }
-    }
+    if (const auto attr = node.try_get_attribute_value<float>("valueStep"))
+        set_value_step(attr.value());
+    if (const auto attr = node.try_get_attribute_value<float>("minValue"))
+        set_min_value(attr.value());
+    if (const auto attr = node.try_get_attribute_value<float>("maxValue"))
+        set_max_value(attr.value());
+    if (const auto attr = node.try_get_attribute_value<float>("defaultValue"))
+        set_value(attr.value());
+    if (const auto attr = node.try_get_attribute_value<layer>("drawLayer"))
+        set_thumb_draw_layer(attr.value());
+    if (const auto attr = node.try_get_attribute_value<orientation>("orientation"))
+        set_orientation(attr.value());
 }
 
 void slider::parse_all_nodes_before_children_(const layout_node& node) {

--- a/src/gui_status_bar_parser.cpp
+++ b/src/gui_status_bar_parser.cpp
@@ -9,36 +9,18 @@ namespace lxgui::gui {
 void status_bar::parse_attributes_(const layout_node& node) {
     frame::parse_attributes_(node);
 
-    if (const layout_attribute* attr = node.try_get_attribute("minValue"))
-        set_min_value(attr->get_value<float>());
-    if (const layout_attribute* attr = node.try_get_attribute("maxValue"))
-        set_max_value(attr->get_value<float>());
-    if (const layout_attribute* attr = node.try_get_attribute("defaultValue"))
-        set_value(attr->get_value<float>());
-    if (const layout_attribute* attr = node.try_get_attribute("drawLayer")) {
-        std::string layer_name = attr->get_value<std::string>();
-        if (auto converted = utils::from_string<layer>(layer_name); converted.has_value()) {
-            set_bar_draw_layer(converted.value());
-        } else {
-            gui::out << gui::warning << node.get_location() << ": Unknown StatusBar draw layer: \""
-                     << layer_name << "\". Attribute ignored." << std::endl;
-        }
-    }
-
-    if (const layout_attribute* attr = node.try_get_attribute("orientation")) {
-        std::string orient = attr->get_value<std::string>();
-        if (auto converted = utils::from_string<orientation>(orient); converted.has_value()) {
-            set_orientation(converted.value());
-        } else {
-            gui::out << gui::warning << node.get_location() << ": Unknown StatusBar orientation: \""
-                     << orient
-                     << "\". Expecting either \"HORIZONTAL\" or \"VERTICAL\". Attribute ignored."
-                     << std::endl;
-        }
-    }
-
-    if (const layout_attribute* attr = node.try_get_attribute("reversed"))
-        set_reversed(attr->get_value<bool>());
+    if (const auto attr = node.try_get_attribute_value<float>("minValue"))
+        set_min_value(attr.value());
+    if (const auto attr = node.try_get_attribute_value<float>("maxValue"))
+        set_max_value(attr.value());
+    if (const auto attr = node.try_get_attribute_value<float>("defaultValue"))
+        set_value(attr.value());
+    if (const auto attr = node.try_get_attribute_value<layer>("drawLayer"))
+        set_bar_draw_layer(attr.value());
+    if (const auto attr = node.try_get_attribute_value<orientation>("orientation"))
+        set_orientation(attr.value());
+    if (const auto attr = node.try_get_attribute_value<bool>("reversed"))
+        set_reversed(attr.value());
 }
 
 void status_bar::parse_all_nodes_before_children_(const layout_node& node) {

--- a/src/gui_texture_parser.cpp
+++ b/src/gui_texture_parser.cpp
@@ -19,19 +19,10 @@ void texture::parse_layout(const layout_node& node) {
 void texture::parse_attributes_(const layout_node& node) {
     layered_region::parse_attributes_(node);
 
-    if (const layout_attribute* attr = node.try_get_attribute("filter")) {
-        std::string filter_name = attr->get_value<std::string>();
-        if (auto converted = utils::from_string<material::filter>(filter_name);
-            converted.has_value()) {
-            set_filter_mode(converted.value());
-        } else {
-            gui::out << gui::warning << node.get_location() << ": Unknown Texture filter type: \""
-                     << filter_name << "\". Attribute ignored." << std::endl;
-        }
-    }
-
-    if (const layout_attribute* attr = node.try_get_attribute("file"))
-        set_texture(attr->get_value<std::string>());
+    if (const auto attr = node.try_get_attribute_value<material::filter>("filter"))
+        set_filter_mode(attr.value());
+    if (const auto attr = node.try_get_attribute_value<std::string>("file"))
+        set_texture(attr.value());
 }
 
 void texture::parse_tex_coords_node_(const layout_node& node) {


### PR DESCRIPTION
Improve error handing and error messages when parsing failure occurs while reading layout files.